### PR TITLE
Add ClusteringResult for clustering transfer and serialization

### DIFF
--- a/docs/source/examples_notebooks/predefined_sequence_example.ipynb
+++ b/docs/source/examples_notebooks/predefined_sequence_example.ipynb
@@ -6,21 +6,7 @@
    "source": [
     "# Saving and Reapplying Clustering Results\n",
     "\n",
-    "This notebook demonstrates the **cluster once, apply many times** workflow using `ClusteringResult`.\n",
-    "\n",
-    "**Common use cases:**\n",
-    "1. **Cluster on a subset of variables** (e.g., wind only), then apply that clustering to all variables\n",
-    "2. **Save clustering to file**, reload later, and apply to updated or different data\n",
-    "3. **Share clustering** across different datasets or team members\n",
-    "\n",
-    "Author: Maximilian Hoffmann"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup"
+    "This notebook demonstrates the **cluster once, apply many times** workflow."
    ]
   },
   {
@@ -29,38 +15,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
-    "from pathlib import Path\n",
-    "\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
-    "\n",
-    "# Configure Plotly for sphinx/nbsphinx output\n",
-    "import plotly.io as pio\n",
+    "import plotly.express as px\n",
     "\n",
     "import tsam\n",
-    "from tsam import ClusterConfig\n",
+    "from tsam import ClusterConfig, ClusteringResult\n",
     "\n",
-    "pio.renderers.default = \"notebook\"\n",
+    "raw = pd.read_csv(\"testdata.csv\", index_col=0)  # 4 columns: GHI, T, Wind, Load"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two Paths to Aggregate\n",
     "\n",
-    "# Ensure results directory exists\n",
-    "RESULTS_DIR = Path(\"results\")\n",
-    "RESULTS_DIR.mkdir(exist_ok=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Input data "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Read in time series from testdata.csv with pandas"
+    "**Path A:** Cluster on ALL variables  \n",
+    "**Path B:** Cluster on WIND only, then apply to all variables"
    ]
   },
   {
@@ -69,452 +41,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw = pd.read_csv(\"testdata.csv\", index_col=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Show a slice of the dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "raw.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Show the shape of the raw input data: 4 types of timeseries (GHI, Temperature, Wind and Load) for every hour in a year"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "raw.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Plot an example series - in this case the wind speed"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Original wind heatmap\n",
-    "tsam.plot.heatmap(raw, column=\"Wind\", period_hours=24, title=\"Original Wind\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 1: Initial Clustering\n",
-    "\n",
-    "First, let's perform a standard aggregation on all variables to establish a baseline."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Initialize an aggregation class object with hierarchical clustering as method for eight typical days, without any integration of extreme periods. Alternative clusterMethod's are 'averaging','hierarchical' and 'k_medoids'."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result = tsam.aggregate(\n",
-    "    raw,\n",
-    "    n_periods=8,\n",
-    "    period_hours=24,\n",
-    "    cluster=ClusterConfig(method=\"hierarchical\", representation=\"medoid\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create the typical periods"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods = result.typical_periods"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Show shape of typical periods: 4 types of timeseries for 8*24 hours"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Repredict the original time series based on the typical periods"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reconstructed = result.reconstruct()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Plot the repredicted data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Predicted wind heatmap (all attributes)\n",
-    "tsam.plot.heatmap(\n",
-    "    reconstructed,\n",
-    "    column=\"Wind\",\n",
-    "    period_hours=24,\n",
-    "    title=\"Predicted Wind (All Attributes)\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Use Case 1: Cluster on Subset, Apply to All\n",
-    "\n",
-    "A common workflow is to cluster on a subset of variables (e.g., wind only) and then apply that clustering to all variables. This ensures the clustering is optimized for the most important variable while still getting aggregated values for everything."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Clustering the solar time series only with 8 typical days and hierarchical clustering leads to different typical days in another sequence."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Isolate wind time series and show first lines of data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "raw_wind = raw.loc[:, \"Wind\"].to_frame()\n",
-    "raw_wind.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now same clustering procedure as above for the isolated wind time series"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_wind = tsam.aggregate(\n",
-    "    raw_wind,\n",
-    "    n_periods=8,\n",
-    "    period_hours=24,\n",
-    "    cluster=ClusterConfig(method=\"hierarchical\", representation=\"medoid\"),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_wind = result_wind.typical_periods"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Export for preprocess time series for testing"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Export preprocessed time series for testing/debugging.\n",
-    "# Note: The _aggregation attribute is internal and may change in future versions.\n",
-    "# This access pattern is appropriate for testing but should not be relied upon in production code.\n",
-    "result_wind._aggregation.normalizedPeriodlyProfiles.to_csv(\n",
-    "    RESULTS_DIR / \"preprocessed_wind.csv\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_wind.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reconstructed_wind = result_wind.reconstruct()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Predicted wind heatmap (wind only)\n",
-    "tsam.plot.heatmap(\n",
-    "    reconstructed_wind,\n",
-    "    column=\"Wind\",\n",
-    "    period_hours=24,\n",
-    "    title=\"Predicted Wind (Wind Only)\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When we compare both plots, we see that 8 typical periods for wind only can better account extreme periods, but the cluster order in general changes"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result.cluster_assignments"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_wind.cluster_assignments"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Applying Wind Clustering to All Variables\n",
-    "\n",
-    "Now we use `ClusteringResult.apply()` to transfer the wind-only clustering to all attributes. This is the key feature: **cluster once, apply many times**."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Apply wind-only clustering to all attributes\n",
-    "result_predef = result_wind.clustering.apply(raw)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_predef = result_predef.typical_periods"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_predef.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Save typical periods to .csv file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_predef.to_csv(RESULTS_DIR / \"testperiods_predef_cluster_order.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reconstructed_predef = result_predef.reconstruct()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we compare the cluster orders"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_wind.cluster_assignments"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_predef.cluster_assignments"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As it can be seen, the cluster order for the four attributes is now identical to the cluster order of the wind time series clustering. Using `ClusteringResult.apply()` transfers both the cluster assignments AND the cluster centers, ensuring the exact same representative periods are used."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Predicted wind heatmap (predefined cluster order)\n",
-    "tsam.plot.heatmap(\n",
-    "    reconstructed_predef,\n",
-    "    column=\"Load\",\n",
-    "    period_hours=24,\n",
-    "    title=\"Predicted Wind (Predefined Cluster Order)\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The wind values in the transferred result match exactly because `ClusteringResult.apply()` transfers:\n",
-    "- **Cluster assignments**: Which days belong to which cluster\n",
-    "- **Cluster centers**: Which original day represents each cluster\n",
-    "- **Representation method**: How typical periods are computed (mean, medoid, etc.)\n",
-    "- **Rescale setting**: Whether to rescale to preserve original means\n",
-    "\n",
-    "### Transferring with Segmentation\n",
-    "\n",
-    "The transfer also works with segmentation. All segment information is preserved:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from tsam import ClusteringResult, SegmentConfig\n",
-    "\n",
-    "# Aggregate wind with segmentation\n",
-    "result_wind_seg = tsam.aggregate(\n",
-    "    raw_wind,\n",
-    "    n_periods=8,\n",
-    "    period_hours=24,\n",
-    "    cluster=ClusterConfig(method=\"hierarchical\", representation=\"medoid\"),\n",
-    "    segments=SegmentConfig(n_segments=6),\n",
+    "# Path A: Cluster on ALL variables\n",
+    "result_all = tsam.aggregate(\n",
+    "    raw, n_periods=8, cluster=ClusterConfig(method=\"hierarchical\")\n",
     ")\n",
     "\n",
-    "# The clustering property contains all transfer state\n",
-    "result_wind_seg.clustering"
+    "# Path B: Cluster on WIND only, then transfer to all\n",
+    "result_wind = tsam.aggregate(\n",
+    "    raw[[\"Wind\"]], n_periods=8, cluster=ClusterConfig(method=\"hierarchical\")\n",
+    ")\n",
+    "result_transferred = result_wind.clustering.apply(raw)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Comparing Cluster Assignments\n",
+    "\n",
+    "- **Row 1** (all variables) differs from **Row 2** (wind only)\n",
+    "- **Row 2** and **Row 3** are **identical** - the transfer preserves the clustering!"
    ]
   },
   {
@@ -523,23 +69,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Transfer everything with the apply() method\n",
-    "result_full_transfer = result_wind_seg.clustering.apply(raw)\n",
-    "\n",
-    "# The result has the same segmented structure\n",
-    "result_full_transfer.typical_periods"
+    "px.imshow(\n",
+    "    pd.DataFrame(\n",
+    "        {\n",
+    "            \"Clustered on ALL variables\": result_all.cluster_assignments,\n",
+    "            \"Clustered on WIND only\": result_wind.cluster_assignments,\n",
+    "            \"Transferred to all variables\": result_transferred.cluster_assignments,\n",
+    "        },\n",
+    "        index=pd.RangeIndex(\n",
+    "            start=0, stop=len(result_all.cluster_assignments), name=\"Original Period\"\n",
+    "        ),\n",
+    "    ).T,\n",
+    "    color_continuous_scale=\"viridis\",\n",
+    "    title=\"Cluster Assignments: Row 2 and 3 are IDENTICAL!\",\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Use Case 2: Save and Load Clustering\n",
+    "## Verifying the Transfer\n",
     "\n",
-    "The `ClusteringResult` can be saved to JSON and loaded later. This enables:\n",
-    "- **Reproducibility**: Store clustering configuration for later use\n",
-    "- **Sharing**: Send clustering results to colleagues\n",
-    "- **Batch processing**: Apply the same clustering to multiple datasets"
+    "The wind typical periods are **identical** - but now we also have GHI, T, and Load:"
    ]
   },
   {
@@ -548,24 +100,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Save to JSON (simple method)\n",
-    "result_wind_seg.clustering.to_json(str(RESULTS_DIR / \"clustering.json\"))\n",
+    "# Wind typical periods: wind-only vs transferred\n",
+    "wind_only = result_wind.typical_periods[\"Wind\"]\n",
+    "wind_transferred = result_transferred.typical_periods[\"Wind\"]\n",
     "\n",
-    "# Load from JSON\n",
-    "clustering_loaded = ClusteringResult.from_json(str(RESULTS_DIR / \"clustering.json\"))\n",
-    "\n",
-    "# Use loaded clustering\n",
-    "result_from_file = clustering_loaded.apply(raw)\n",
-    "result_from_file.typical_periods.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Unified Assignments DataFrame\n",
-    "\n",
-    "The `assignments` property provides a convenient DataFrame with all assignment information for each original timestep:"
+    "print(\n",
+    "    \"Wind typical periods IDENTICAL after transfer:\", wind_only.equals(wind_transferred)\n",
+    ")\n",
+    "print(f\"Max difference: {(wind_only - wind_transferred).abs().max()}\")"
    ]
   },
   {
@@ -574,17 +116,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Unified assignments DataFrame\n",
-    "result_full_transfer.assignments.head(30)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Use Case 3: Apply to Different Data\n",
-    "\n",
-    "A key feature is applying saved clustering to completely different data - for example, a different year or updated forecasts. The clustering structure (which days belong to which cluster) remains the same, but the values come from the new data."
+    "# Verify: cluster assignments are equal\n",
+    "print(\n",
+    "    \"Cluster assignments equal:\",\n",
+    "    np.array_equal(\n",
+    "        result_wind.cluster_assignments, result_transferred.cluster_assignments\n",
+    "    ),\n",
+    ")"
    ]
   },
   {
@@ -593,30 +131,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Simulate a \"different year\" by scaling the data\n",
-    "# In practice, this would be actual data from another year\n",
-    "raw_year2 = raw.copy()\n",
-    "raw_year2[\"Wind\"] = raw_year2[\"Wind\"] * 1.1  # 10% more wind\n",
-    "raw_year2[\"Load\"] = raw_year2[\"Load\"] * 0.95  # 5% less load\n",
-    "\n",
-    "# Apply the SAME clustering to the new data\n",
-    "result_year2 = clustering_loaded.apply(raw_year2)\n",
-    "\n",
-    "print(\"Original year wind mean:\", raw[\"Wind\"].mean())\n",
-    "print(\"Year 2 wind mean:\", raw_year2[\"Wind\"].mean())\n",
-    "print()\n",
-    "print(\"Typical periods from original:\", result_from_file.typical_periods[\"Wind\"].mean())\n",
-    "print(\"Typical periods from year 2:\", result_year2.typical_periods[\"Wind\"].mean())"
+    "# But now we have ALL columns!\n",
+    "print(\"Wind-only result columns:\", result_wind.typical_periods.columns.tolist())\n",
+    "print(\n",
+    "    \"Transferred result columns:\", result_transferred.typical_periods.columns.tolist()\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The same 8 cluster assignments are used, but the typical period values reflect the new data. This is useful for:\n",
-    "- Comparing different scenarios with consistent time structure\n",
-    "- Energy system optimization where the time structure must match across scenarios\n",
-    "- Sensitivity analysis with modified input data"
+    "## Use Case: Save and Reload Clustering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save clustering to file\n",
+    "result_wind.clustering.to_json(\"clustering.json\")\n",
+    "\n",
+    "# Later: load and apply to any data\n",
+    "clustering = ClusteringResult.from_json(\"clustering.json\")\n",
+    "result_reloaded = clustering.apply(raw)\n",
+    "\n",
+    "print(\n",
+    "    \"Reloaded result identical:\",\n",
+    "    result_transferred.typical_periods.equals(result_reloaded.typical_periods),\n",
+    ")"
    ]
   },
   {
@@ -625,53 +170,30 @@
    "source": [
     "## Summary\n",
     "\n",
-    "This notebook demonstrated the **cluster once, apply many times** workflow:\n",
+    "```python\n",
+    "# Cluster on subset\n",
+    "result_wind = tsam.aggregate(data[[\"Wind\"]], n_periods=8)\n",
     "\n",
-    "1. **`result.clustering`** - Access the `ClusteringResult` from any aggregation result\n",
-    "2. **`clustering.apply(data)`** - Apply clustering to any compatible data\n",
-    "3. **`clustering.to_json(path)`** - Save clustering to file\n",
-    "4. **`ClusteringResult.from_json(path)`** - Load clustering from file\n",
+    "# Apply to all variables - wind stays identical!\n",
+    "result_all = result_wind.clustering.apply(data)\n",
     "\n",
-    "The `ClusteringResult` preserves all state needed for deterministic transfer:\n",
-    "- Cluster assignments and centers\n",
-    "- Segmentation structure (if used)\n",
-    "- Representation method (mean, medoid, etc.)\n",
-    "- Rescale settings"
+    "# Save for later\n",
+    "result_wind.clustering.to_json(\"clustering.json\")\n",
+    "```"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tsam_env",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.8"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": true,
-   "sideBar": true,
-   "skip_h1_title": true,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": true
+   "version": "3.12.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/source/examples_notebooks/predefined_sequence_example.ipynb
+++ b/docs/source/examples_notebooks/predefined_sequence_example.ipynb
@@ -599,9 +599,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Simplified Transfer with `predefined`\n",
+    "### Simplified Transfer with `ClusteringResult`\n",
     "\n",
-    "The simplest way to transfer all assignments (cluster order, cluster centers, and segments) is to use the `predefined` parameter with `result.predefined`."
+    "The simplest way to transfer all assignments (cluster order, cluster centers, and segments) is to use `result.clustering.apply()`. The `ClusteringResult` object bundles all transfer state and can be saved/loaded via JSON."
    ]
   },
   {
@@ -610,7 +610,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tsam import PredefinedConfig, SegmentConfig"
+    "from tsam import ClusteringResult, SegmentConfig"
    ]
   },
   {
@@ -640,7 +640,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Get the `predefined` config which contains all transfer state:"
+    "Get the `clustering` result which contains all transfer state:"
    ]
   },
   {
@@ -649,8 +649,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The predefined property contains all transfer state\n",
-    "result_wind_seg.predefined"
+    "# The clustering property contains all transfer state\n",
+    "result_wind_seg.clustering"
    ]
   },
   {
@@ -660,14 +660,14 @@
    "outputs": [],
    "source": [
     "# Can be serialized to JSON\n",
-    "result_wind_seg.predefined.to_dict()"
+    "result_wind_seg.clustering.to_dict()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Transfer to all attributes with a single `predefined` parameter:"
+    "Transfer to all attributes using the `apply()` method:"
    ]
   },
   {
@@ -676,13 +676,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Transfer everything with a single predefined parameter\n",
-    "result_full_transfer = tsam.aggregate(\n",
-    "    raw,\n",
-    "    n_periods=8,\n",
-    "    period_hours=24,\n",
-    "    predefined=result_wind_seg.predefined,\n",
-    ")"
+    "# Transfer everything with the apply() method\n",
+    "result_full_transfer = result_wind_seg.clustering.apply(raw)"
    ]
   },
   {
@@ -699,9 +694,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Saving and Loading predefined\n",
+    "### Saving and Loading ClusteringResult\n",
     "\n",
-    "The `predefined` can be saved to JSON and loaded later:"
+    "The `ClusteringResult` can be saved to JSON and loaded later using `to_json()` and `from_json()`:"
    ]
   },
   {
@@ -710,18 +705,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
-    "\n",
-    "# Save to JSON\n",
-    "with open(RESULTS_DIR / \"predefined.json\", \"w\") as f:\n",
-    "    json.dump(result_wind_seg.predefined.to_dict(), f, indent=2)\n",
+    "# Save to JSON (simple method)\n",
+    "result_wind_seg.clustering.to_json(str(RESULTS_DIR / \"clustering.json\"))\n",
     "\n",
     "# Load from JSON\n",
-    "with open(RESULTS_DIR / \"predefined.json\") as f:\n",
-    "    predef_loaded = PredefinedConfig.from_dict(json.load(f))\n",
+    "clustering_loaded = ClusteringResult.from_json(str(RESULTS_DIR / \"clustering.json\"))\n",
     "\n",
-    "# Use loaded predefined\n",
-    "result_from_file = tsam.aggregate(raw, n_periods=8, predefined=predef_loaded)\n",
+    "# Use loaded clustering\n",
+    "result_from_file = clustering_loaded.apply(raw)\n",
     "result_from_file.typical_periods.head()"
    ]
   },

--- a/docs/source/examples_notebooks/predefined_sequence_example.ipynb
+++ b/docs/source/examples_notebooks/predefined_sequence_example.ipynb
@@ -4,10 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Predefined Cluster Sequences\n",
-    "Example demonstrating how to use predefined cluster assignments and centers.\n",
+    "# Saving and Reapplying Clustering Results\n",
     "\n",
-    "This is useful when you want to transfer clustering results from one time series to another.\n",
+    "This notebook demonstrates the **cluster once, apply many times** workflow using `ClusteringResult`.\n",
+    "\n",
+    "**Common use cases:**\n",
+    "1. **Cluster on a subset of variables** (e.g., wind only), then apply that clustering to all variables\n",
+    "2. **Save clustering to file**, reload later, and apply to updated or different data\n",
+    "3. **Share clustering** across different datasets or team members\n",
     "\n",
     "Author: Maximilian Hoffmann"
    ]
@@ -16,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Import pandas and the relevant time series aggregation class"
+    "## Setup"
    ]
   },
   {
@@ -121,7 +125,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Hierarchical aggregation"
+    "## Step 1: Initial Clustering\n",
+    "\n",
+    "First, let's perform a standard aggregation on all variables to establish a baseline."
    ]
   },
   {
@@ -228,7 +234,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Now cluster the wind time series only"
+    "## Use Case 1: Cluster on Subset, Apply to All\n",
+    "\n",
+    "A common workflow is to cluster on a subset of variables (e.g., wind only) and then apply that clustering to all variables. This ensures the clustering is optimized for the most important variable while still getting aggregated values for everything."
    ]
   },
   {
@@ -368,16 +376,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Transferring clustering to different data\n",
+    "### Applying Wind Clustering to All Variables\n",
     "\n",
-    "tsam offers a simple way to apply clustering results from one dataset to another using `ClusteringResult.apply()`. This is useful when you want to cluster on a subset of variables (e.g., wind only) but then apply that clustering to all variables."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We use `ClusteringResult.apply()` to transfer the wind-only clustering to all attributes:"
+    "Now we use `ClusteringResult.apply()` to transfer the wind-only clustering to all attributes. This is the key feature: **cluster once, apply many times**."
    ]
   },
   {
@@ -474,7 +475,7 @@
     "# Predicted wind heatmap (predefined cluster order)\n",
     "tsam.plot.heatmap(\n",
     "    reconstructed_predef,\n",
-    "    column=\"Wind\",\n",
+    "    column=\"Load\",\n",
     "    period_hours=24,\n",
     "    title=\"Predicted Wind (Predefined Cluster Order)\",\n",
     ")"
@@ -484,7 +485,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The wind values in the transferred result match exactly because both the cluster assignments and the cluster centers are transferred together via `ClusteringResult.apply()`."
+    "The wind values in the transferred result match exactly because `ClusteringResult.apply()` transfers:\n",
+    "- **Cluster assignments**: Which days belong to which cluster\n",
+    "- **Cluster centers**: Which original day represents each cluster\n",
+    "- **Representation method**: How typical periods are computed (mean, medoid, etc.)\n",
+    "- **Rescale setting**: Whether to rescale to preserve original means\n",
+    "\n",
+    "### Transferring with Segmentation\n",
+    "\n",
+    "The transfer also works with segmentation. All segment information is preserved:"
    ]
   },
   {
@@ -525,9 +534,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Saving and Loading ClusteringResult\n",
+    "## Use Case 2: Save and Load Clustering\n",
     "\n",
-    "The `ClusteringResult` can be saved to JSON and loaded later using `to_json()` and `from_json()`:"
+    "The `ClusteringResult` can be saved to JSON and loaded later. This enables:\n",
+    "- **Reproducibility**: Store clustering configuration for later use\n",
+    "- **Sharing**: Send clustering results to colleagues\n",
+    "- **Batch processing**: Apply the same clustering to multiple datasets"
    ]
   },
   {
@@ -564,6 +576,67 @@
    "source": [
     "# Unified assignments DataFrame\n",
     "result_full_transfer.assignments.head(30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Case 3: Apply to Different Data\n",
+    "\n",
+    "A key feature is applying saved clustering to completely different data - for example, a different year or updated forecasts. The clustering structure (which days belong to which cluster) remains the same, but the values come from the new data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simulate a \"different year\" by scaling the data\n",
+    "# In practice, this would be actual data from another year\n",
+    "raw_year2 = raw.copy()\n",
+    "raw_year2[\"Wind\"] = raw_year2[\"Wind\"] * 1.1  # 10% more wind\n",
+    "raw_year2[\"Load\"] = raw_year2[\"Load\"] * 0.95  # 5% less load\n",
+    "\n",
+    "# Apply the SAME clustering to the new data\n",
+    "result_year2 = clustering_loaded.apply(raw_year2)\n",
+    "\n",
+    "print(\"Original year wind mean:\", raw[\"Wind\"].mean())\n",
+    "print(\"Year 2 wind mean:\", raw_year2[\"Wind\"].mean())\n",
+    "print()\n",
+    "print(\"Typical periods from original:\", result_from_file.typical_periods[\"Wind\"].mean())\n",
+    "print(\"Typical periods from year 2:\", result_year2.typical_periods[\"Wind\"].mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same 8 cluster assignments are used, but the typical period values reflect the new data. This is useful for:\n",
+    "- Comparing different scenarios with consistent time structure\n",
+    "- Energy system optimization where the time structure must match across scenarios\n",
+    "- Sensitivity analysis with modified input data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook demonstrated the **cluster once, apply many times** workflow:\n",
+    "\n",
+    "1. **`result.clustering`** - Access the `ClusteringResult` from any aggregation result\n",
+    "2. **`clustering.apply(data)`** - Apply clustering to any compatible data\n",
+    "3. **`clustering.to_json(path)`** - Save clustering to file\n",
+    "4. **`ClusteringResult.from_json(path)`** - Load clustering from file\n",
+    "\n",
+    "The `ClusteringResult` preserves all state needed for deterministic transfer:\n",
+    "- Cluster assignments and centers\n",
+    "- Segmentation structure (if used)\n",
+    "- Representation method (mean, medoid, etc.)\n",
+    "- Rescale settings"
    ]
   }
  ],

--- a/docs/source/examples_notebooks/predefined_sequence_example.ipynb
+++ b/docs/source/examples_notebooks/predefined_sequence_example.ipynb
@@ -368,14 +368,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Predefining cluster sequence"
+    "### Transferring clustering to different data\n",
+    "\n",
+    "tsam offers a simple way to apply clustering results from one dataset to another using `ClusteringResult.apply()`. This is useful when you want to cluster on a subset of variables (e.g., wind only) but then apply that clustering to all variables."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "tsam offers the option to aggregate input time series for a predefined cluster order. This means that we can take the cluster Order from the wind time series only and set it as input for the aggregation process for all attributes"
+    "We use `ClusteringResult.apply()` to transfer the wind-only clustering to all attributes:"
    ]
   },
   {
@@ -384,17 +386,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use predefined cluster order from the wind-only aggregation\n",
-    "result_predef = tsam.aggregate(\n",
-    "    raw,\n",
-    "    n_periods=8,\n",
-    "    period_hours=24,\n",
-    "    cluster=ClusterConfig(\n",
-    "        method=\"hierarchical\",\n",
-    "        representation=\"medoid\",\n",
-    "        predef_cluster_order=tuple(result_wind.cluster_assignments),\n",
-    "    ),\n",
-    ")"
+    "# Apply wind-only clustering to all attributes\n",
+    "result_predef = result_wind.clustering.apply(raw)"
    ]
   },
   {
@@ -469,7 +462,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As it can be seen, the cluster order for the four attributes (i.e. he sequence of typical days) is no identical to the cluster order of the wind time series clustering. Now the color plots can be compared:"
+    "As it can be seen, the cluster order for the four attributes is now identical to the cluster order of the wind time series clustering. Using `ClusteringResult.apply()` transfers both the cluster assignments AND the cluster centers, ensuring the exact same representative periods are used."
    ]
   },
   {
@@ -491,21 +484,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As it can be seen, the plot for the aggregated wind time series only and the one for four with the predefined cluster Order from the wind time series still differ from each other. This is because of the fact, that only the cluster Order, but not the cluster centers of each cluster are predefined. Since these are in one case deterined for the wind time series only and in the other case for all four attributes in common, the chosen cluster centers (chosen typical days) differ from each other"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Predefining cluster order and cluster centers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If the cluster order and the cluster centers should be taken from the wind time series clustering, we pass the information which days where chosen as typical days for the wind time series to the aggregation of all four typical attributes as well"
+    "The wind values in the transferred result match exactly because both the cluster assignments and the cluster centers are transferred together via `ClusteringResult.apply()`."
    ]
   },
   {
@@ -514,118 +493,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use predefined cluster order AND cluster centers from wind-only aggregation\n",
-    "result_predef_with_centers = tsam.aggregate(\n",
-    "    raw,\n",
-    "    n_periods=8,\n",
-    "    period_hours=24,\n",
-    "    cluster=ClusterConfig(\n",
-    "        method=\"hierarchical\",\n",
-    "        representation=\"medoid\",\n",
-    "        predef_cluster_order=tuple(result_wind.cluster_assignments),\n",
-    "        predef_cluster_centers=tuple(result_wind.cluster_center_indices),\n",
-    "    ),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_predef_with_centers = result_predef_with_centers.typical_periods"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_predef_with_centers.shape"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Save typical periods to .csv file"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "typical_periods_predef_with_centers.to_csv(\n",
-    "    RESULTS_DIR / \"testperiods_predef_order_and_centers.csv\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reconstructed_predef_with_centers = result_predef_with_centers.reconstruct()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Predicted wind heatmap (predefined cluster order and centers)\n",
-    "tsam.plot.heatmap(\n",
-    "    reconstructed_predef_with_centers,\n",
-    "    column=\"Wind\",\n",
-    "    period_hours=24,\n",
-    "    title=\"Predicted Wind (Predefined Order & Centers)\",\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now even the chosen typical days for the four attributes are the same as for the aggregated wind time series only"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Simplified Transfer with `ClusteringResult`\n",
+    "from tsam import ClusteringResult, SegmentConfig\n",
     "\n",
-    "The simplest way to transfer all assignments (cluster order, cluster centers, and segments) is to use `result.clustering.apply()`. The `ClusteringResult` object bundles all transfer state and can be saved/loaded via JSON."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from tsam import ClusteringResult, SegmentConfig"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "First, aggregate the wind time series with segmentation:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Aggregate wind with segmentation\n",
     "result_wind_seg = tsam.aggregate(\n",
     "    raw_wind,\n",
@@ -633,22 +502,8 @@
     "    period_hours=24,\n",
     "    cluster=ClusterConfig(method=\"hierarchical\", representation=\"medoid\"),\n",
     "    segments=SegmentConfig(n_segments=6),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Get the `clustering` result which contains all transfer state:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    ")\n",
+    "\n",
     "# The clustering property contains all transfer state\n",
     "result_wind_seg.clustering"
    ]
@@ -659,33 +514,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Can be serialized to JSON\n",
-    "result_wind_seg.clustering.to_dict()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Transfer to all attributes using the `apply()` method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Transfer everything with the apply() method\n",
-    "result_full_transfer = result_wind_seg.clustering.apply(raw)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "result_full_transfer = result_wind_seg.clustering.apply(raw)\n",
+    "\n",
     "# The result has the same segmented structure\n",
     "result_full_transfer.typical_periods"
    ]

--- a/src/tsam/__init__.py
+++ b/src/tsam/__init__.py
@@ -53,7 +53,7 @@ def __getattr__(name: str):
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-from tsam.config import ClusterConfig, ExtremeConfig, PredefinedConfig, SegmentConfig
+from tsam.config import ClusterConfig, ClusteringResult, ExtremeConfig, SegmentConfig
 from tsam.result import AccuracyMetrics, AggregationResult
 
 # Legacy imports for backward compatibility
@@ -65,8 +65,8 @@ __all__ = [
     "AccuracyMetrics",
     "AggregationResult",
     "ClusterConfig",
+    "ClusteringResult",
     "ExtremeConfig",
-    "PredefinedConfig",
     "SegmentConfig",
     "TimeSeriesAggregation",
     "aggregate",

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -253,9 +253,6 @@ def aggregate(
         n_timesteps_per_period=agg.timeStepsPerPeriod,
         n_segments=segments.n_segments if segments else None,
         segment_durations=agg.segmentDurationDict if segments else None,
-        cluster_center_indices=np.array(agg.clusterCenterIndices)
-        if agg.clusterCenterIndices is not None
-        else None,
         accuracy=accuracy,
         clustering_duration=getattr(agg, "clusteringDuration", 0.0),
         _aggregation=agg,

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -11,6 +11,7 @@ from tsam.config import (
     ClusterConfig,
     ClusteringResult,
     ExtremeConfig,
+    RepresentationMethod,
     SegmentConfig,
 )
 from tsam.result import AccuracyMetrics, AggregationResult
@@ -276,6 +277,9 @@ def _build_clustering_result(
     extremes_config: ExtremeConfig | None,
     rescale: bool,
     resolution: float | None,
+    *,
+    representation: RepresentationMethod | None = None,
+    segment_representation: RepresentationMethod | None = None,
 ) -> ClusteringResult:
     """Build ClusteringResult from a TimeSeriesAggregation object."""
     # Get cluster centers (convert to Python ints for JSON serialization)
@@ -306,6 +310,18 @@ def _build_clustering_result(
         segment_order = tuple(segment_order_list)
         segment_durations = tuple(segment_durations_list)
 
+    # Determine representation values
+    # If explicitly provided, use them; otherwise extract from configs
+    effective_representation = representation
+    if effective_representation is None and cluster_config is not None:
+        effective_representation = cluster_config.get_representation()
+    if effective_representation is None:
+        effective_representation = "medoid"
+
+    effective_segment_representation = segment_representation
+    if effective_segment_representation is None and segment_config is not None:
+        effective_segment_representation = segment_config.representation
+
     return ClusteringResult(
         period_hours=agg.hoursPerPeriod,
         cluster_order=tuple(int(x) for x in agg.clusterOrder),
@@ -313,11 +329,13 @@ def _build_clustering_result(
         segment_order=segment_order,
         segment_durations=segment_durations,
         segment_centers=None,  # Not currently captured by segmentation
+        rescale=rescale,
+        representation=effective_representation,
+        segment_representation=effective_segment_representation,
+        resolution=resolution,
         cluster_config=cluster_config,
         segment_config=segment_config,
         extremes_config=extremes_config,
-        rescale=rescale,
-        resolution=resolution,
     )
 
 

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -273,6 +273,13 @@ def _build_old_params(
     rescale: bool,
     round_decimals: int | None,
     numerical_tolerance: float,
+    *,
+    # Predefined parameters (used internally by ClusteringResult.apply())
+    predef_cluster_order: tuple[int, ...] | None = None,
+    predef_cluster_centers: tuple[int, ...] | None = None,
+    predef_segment_order: tuple[tuple[int, ...], ...] | None = None,
+    predef_segment_durations: tuple[tuple[int, ...], ...] | None = None,
+    predef_segment_centers: tuple[tuple[int, ...], ...] | None = None,
 ) -> dict:
     """Build parameters for the old TimeSeriesAggregation API."""
     params: dict = {
@@ -314,11 +321,12 @@ def _build_old_params(
     if cluster.weights is not None:
         params["weightDict"] = cluster.weights
 
-    if cluster.predef_cluster_order is not None:
-        params["predefClusterOrder"] = list(cluster.predef_cluster_order)
+    # Predefined cluster parameters (from ClusteringResult)
+    if predef_cluster_order is not None:
+        params["predefClusterOrder"] = list(predef_cluster_order)
 
-    if cluster.predef_cluster_centers is not None:
-        params["predefClusterCenterIndices"] = list(cluster.predef_cluster_centers)
+    if predef_cluster_centers is not None:
+        params["predefClusterCenterIndices"] = list(predef_cluster_centers)
 
     # Segmentation config
     if segments is not None:
@@ -328,19 +336,15 @@ def _build_old_params(
             segments.representation, "meanRepresentation"
         )
 
-        # Predefined segment parameters
-        if segments.predef_segment_order is not None:
-            params["predefSegmentOrder"] = [
-                list(s) for s in segments.predef_segment_order
-            ]
-        if segments.predef_segment_durations is not None:
+        # Predefined segment parameters (from ClusteringResult)
+        if predef_segment_order is not None:
+            params["predefSegmentOrder"] = [list(s) for s in predef_segment_order]
+        if predef_segment_durations is not None:
             params["predefSegmentDurations"] = [
-                list(s) for s in segments.predef_segment_durations
+                list(s) for s in predef_segment_durations
             ]
-        if segments.predef_segment_centers is not None:
-            params["predefSegmentCenters"] = [
-                list(s) for s in segments.predef_segment_centers
-            ]
+        if predef_segment_centers is not None:
+            params["predefSegmentCenters"] = [list(s) for s in predef_segment_centers]
     else:
         params["segmentation"] = False
 

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -256,6 +256,9 @@ def aggregate(
         accuracy=accuracy,
         clustering_duration=getattr(agg, "clusteringDuration", 0.0),
         _aggregation=agg,
+        _cluster_config=cluster,
+        _segment_config=segments,
+        _rescale=rescale,
     )
 
 

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -11,7 +11,6 @@ from tsam.config import (
     ClusterConfig,
     ClusteringResult,
     ExtremeConfig,
-    RepresentationMethod,
     SegmentConfig,
 )
 from tsam.result import AccuracyMetrics, AggregationResult
@@ -272,14 +271,11 @@ def aggregate(
 def _build_clustering_result(
     agg: TimeSeriesAggregation,
     n_segments: int | None,
-    cluster_config: ClusterConfig | None,
+    cluster_config: ClusterConfig,
     segment_config: SegmentConfig | None,
     extremes_config: ExtremeConfig | None,
     rescale: bool,
     resolution: float | None,
-    *,
-    representation: RepresentationMethod | None = None,
-    segment_representation: RepresentationMethod | None = None,
 ) -> ClusteringResult:
     """Build ClusteringResult from a TimeSeriesAggregation object."""
     # Get cluster centers (convert to Python ints for JSON serialization)
@@ -310,17 +306,9 @@ def _build_clustering_result(
         segment_order = tuple(segment_order_list)
         segment_durations = tuple(segment_durations_list)
 
-    # Determine representation values
-    # If explicitly provided, use them; otherwise extract from configs
-    effective_representation = representation
-    if effective_representation is None and cluster_config is not None:
-        effective_representation = cluster_config.get_representation()
-    if effective_representation is None:
-        effective_representation = "medoid"
-
-    effective_segment_representation = segment_representation
-    if effective_segment_representation is None and segment_config is not None:
-        effective_segment_representation = segment_config.representation
+    # Extract representation from configs
+    representation = cluster_config.get_representation()
+    segment_representation = segment_config.representation if segment_config else None
 
     return ClusteringResult(
         period_hours=agg.hoursPerPeriod,
@@ -330,8 +318,8 @@ def _build_clustering_result(
         segment_durations=segment_durations,
         segment_centers=None,  # Not currently captured by segmentation
         rescale=rescale,
-        representation=effective_representation,
-        segment_representation=effective_segment_representation,
+        representation=representation,
+        segment_representation=segment_representation,
         resolution=resolution,
         cluster_config=cluster_config,
         segment_config=segment_config,

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import numpy as np
 import pandas as pd
 
 from tsam.config import (
@@ -251,17 +250,16 @@ def aggregate(
         n_segments=segments.n_segments if segments else None,
         cluster_config=cluster,
         segment_config=segments,
+        extremes_config=extremes,
         rescale=rescale,
+        resolution=resolution,
     )
 
     # Build result object
     return AggregationResult(
         typical_periods=typical_periods,
-        cluster_assignments=np.array(agg.clusterOrder),
         cluster_weights=dict(agg.clusterPeriodNoOccur),
-        n_periods=len(agg.clusterPeriodIdx),
         n_timesteps_per_period=agg.timeStepsPerPeriod,
-        n_segments=segments.n_segments if segments else None,
         segment_durations=agg.segmentDurationDict if segments else None,
         accuracy=accuracy,
         clustering_duration=getattr(agg, "clusteringDuration", 0.0),
@@ -275,7 +273,9 @@ def _build_clustering_result(
     n_segments: int | None,
     cluster_config: ClusterConfig | None,
     segment_config: SegmentConfig | None,
+    extremes_config: ExtremeConfig | None,
     rescale: bool,
+    resolution: float | None,
 ) -> ClusteringResult:
     """Build ClusteringResult from a TimeSeriesAggregation object."""
     # Get cluster centers (convert to Python ints for JSON serialization)
@@ -315,7 +315,9 @@ def _build_clustering_result(
         segment_centers=None,  # Not currently captured by segmentation
         cluster_config=cluster_config,
         segment_config=segment_config,
+        extremes_config=extremes_config,
         rescale=rescale,
+        resolution=resolution,
     )
 
 

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -11,7 +11,6 @@ from tsam.config import (
     REPRESENTATION_MAPPING,
     ClusterConfig,
     ExtremeConfig,
-    PredefinedConfig,
     SegmentConfig,
 )
 from tsam.result import AccuracyMetrics, AggregationResult
@@ -27,7 +26,6 @@ def aggregate(
     cluster: ClusterConfig | None = None,
     segments: SegmentConfig | None = None,
     extremes: ExtremeConfig | None = None,
-    predefined: PredefinedConfig | dict | None = None,
     rescale: bool = True,
     round_decimals: int | None = None,
     numerical_tolerance: float = 1e-13,
@@ -73,11 +71,6 @@ def aggregate(
     extremes : ExtremeConfig, optional
         Configuration for preserving extreme periods.
         If not provided, no extreme period handling is applied.
-
-    predefined : PredefinedConfig or dict, optional
-        Predefined assignments from a previous aggregation result.
-        Use `result.predefined` to get this, or load from JSON with
-        `PredefinedConfig.from_dict()`. Overrides cluster/segment assignments.
 
     rescale : bool, default True
         Rescale typical periods to match the original data's mean.
@@ -148,7 +141,7 @@ def aggregate(
     Transferring assignments to new data:
 
     >>> result1 = aggregate(df_wind, n_periods=8)
-    >>> result2 = aggregate(df_all, n_periods=8, predefined=result1.predefined)
+    >>> result2 = result1.clustering.apply(df_all)
 
     See Also
     --------
@@ -170,51 +163,6 @@ def aggregate(
     # Apply defaults
     if cluster is None:
         cluster = ClusterConfig()
-
-    # Apply predefined overrides
-    if predefined is not None:
-        # Convert dict to PredefinedConfig if needed
-        if isinstance(predefined, dict):
-            predefined = PredefinedConfig.from_dict(predefined)
-
-        # Override cluster config with predefined values
-        cluster_kwargs = {
-            "method": cluster.method,
-            "representation": cluster.representation,
-            "weights": cluster.weights,
-            "normalize_means": cluster.normalize_means,
-            "use_duration_curves": cluster.use_duration_curves,
-            "include_period_sums": cluster.include_period_sums,
-            "solver": cluster.solver,
-            "predef_cluster_order": predefined.cluster_order,
-        }
-        if predefined.cluster_centers is not None:
-            cluster_kwargs["predef_cluster_centers"] = predefined.cluster_centers
-        cluster = ClusterConfig(**cluster_kwargs)  # type: ignore[arg-type]
-
-        # Override segment config with predefined values if present
-        if (
-            predefined.segment_order is not None
-            and predefined.segment_durations is not None
-            and len(predefined.segment_durations) > 0
-        ):
-            if segments is None:
-                # Infer n_segments from the predefined data
-                n_segments = len(predefined.segment_durations[0])
-                segments = SegmentConfig(
-                    n_segments=n_segments,
-                    predef_segment_order=predefined.segment_order,
-                    predef_segment_durations=predefined.segment_durations,
-                )
-            else:
-                # Merge with existing segment config
-                segments = SegmentConfig(
-                    n_segments=segments.n_segments,
-                    representation=segments.representation,
-                    predef_segment_order=predefined.segment_order,
-                    predef_segment_durations=predefined.segment_durations,
-                    predef_segment_centers=segments.predef_segment_centers,
-                )
 
     # Validate segments against data
     if segments is not None:

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -10,6 +10,7 @@ from tsam.config import (
     METHOD_MAPPING,
     REPRESENTATION_MAPPING,
     ClusterConfig,
+    ClusteringResult,
     ExtremeConfig,
     SegmentConfig,
 )
@@ -244,6 +245,15 @@ def aggregate(
         rescale_deviations=rescale_deviations,
     )
 
+    # Build ClusteringResult
+    clustering_result = _build_clustering_result(
+        agg=agg,
+        n_segments=segments.n_segments if segments else None,
+        cluster_config=cluster,
+        segment_config=segments,
+        rescale=rescale,
+    )
+
     # Build result object
     return AggregationResult(
         typical_periods=typical_periods,
@@ -255,10 +265,57 @@ def aggregate(
         segment_durations=agg.segmentDurationDict if segments else None,
         accuracy=accuracy,
         clustering_duration=getattr(agg, "clusteringDuration", 0.0),
+        clustering=clustering_result,
         _aggregation=agg,
-        _cluster_config=cluster,
-        _segment_config=segments,
-        _rescale=rescale,
+    )
+
+
+def _build_clustering_result(
+    agg: TimeSeriesAggregation,
+    n_segments: int | None,
+    cluster_config: ClusterConfig | None,
+    segment_config: SegmentConfig | None,
+    rescale: bool,
+) -> ClusteringResult:
+    """Build ClusteringResult from a TimeSeriesAggregation object."""
+    # Get cluster centers (convert to Python ints for JSON serialization)
+    cluster_centers: tuple[int, ...] | None = None
+    if agg.clusterCenterIndices is not None:
+        cluster_centers = tuple(int(x) for x in agg.clusterCenterIndices)
+
+    # Compute segment data if segmentation was used
+    segment_order: tuple[tuple[int, ...], ...] | None = None
+    segment_durations: tuple[tuple[int, ...], ...] | None = None
+
+    if n_segments is not None and hasattr(agg, "segmentedNormalizedTypicalPeriods"):
+        segmented_df = agg.segmentedNormalizedTypicalPeriods
+        segment_order_list = []
+        segment_durations_list = []
+
+        for period_idx in segmented_df.index.get_level_values(0).unique():
+            period_data = segmented_df.loc[period_idx]
+            # Index levels: Segment Step, Segment Duration, Original Start Step
+            assignments = []
+            durations = []
+            for seg_step, seg_dur, _orig_start in period_data.index:
+                assignments.extend([int(seg_step)] * int(seg_dur))
+                durations.append(int(seg_dur))
+            segment_order_list.append(tuple(assignments))
+            segment_durations_list.append(tuple(durations))
+
+        segment_order = tuple(segment_order_list)
+        segment_durations = tuple(segment_durations_list)
+
+    return ClusteringResult(
+        period_hours=agg.hoursPerPeriod,
+        cluster_order=tuple(int(x) for x in agg.clusterOrder),
+        cluster_centers=cluster_centers,
+        segment_order=segment_order,
+        segment_durations=segment_durations,
+        segment_centers=None,  # Not currently captured by segmentation
+        cluster_config=cluster_config,
+        segment_config=segment_config,
+        rescale=rescale,
     )
 
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -508,9 +508,6 @@ class ClusteringResult:
             n_timesteps_per_period=agg.timeStepsPerPeriod,
             n_segments=n_segments,
             segment_durations=agg.segmentDurationDict if n_segments else None,
-            cluster_center_indices=np.array(agg.clusterCenterIndices)
-            if agg.clusterCenterIndices is not None
-            else None,
             accuracy=accuracy,
             clustering_duration=getattr(agg, "clusteringDuration", 0.0),
             _aggregation=agg,

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -575,8 +575,19 @@ class ClusteringResult:
             rescale_deviations=rescale_deviations,
         )
 
+        # Build ClusteringResult - use stored configs if available
+        from tsam.api import _build_clustering_result
+
+        effective_rescale = self.rescale if self.rescale is not None else rescale
+        clustering_result = _build_clustering_result(
+            agg=agg,
+            n_segments=n_segments,
+            cluster_config=self.cluster_config or cluster,
+            segment_config=self.segment_config or segments,
+            rescale=effective_rescale,
+        )
+
         # Build result object
-        # Use stored configs if available, otherwise use what was passed/defaulted
         return AggregationResult(
             typical_periods=typical_periods,
             cluster_assignments=np.array(agg.clusterOrder),
@@ -587,10 +598,8 @@ class ClusteringResult:
             segment_durations=agg.segmentDurationDict if n_segments else None,
             accuracy=accuracy,
             clustering_duration=getattr(agg, "clusteringDuration", 0.0),
+            clustering=clustering_result,
             _aggregation=agg,
-            _cluster_config=self.cluster_config or cluster,
-            _segment_config=self.segment_config or segments,
-            _rescale=self.rescale if self.rescale is not None else rescale,
         )
 
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -230,6 +230,18 @@ class ClusteringResult:
         Indices of timesteps used as segment centers, per typical period.
         Required for fully deterministic segment replication.
 
+    rescale : bool, default True
+        Whether to rescale typical periods to match original data means.
+
+    representation : str, default "medoid"
+        How to compute typical periods from cluster members.
+
+    segment_representation : str, optional
+        How to compute segment values. Only used if segmentation is present.
+
+    resolution : float, optional
+        Time resolution of input data in hours. If not provided, inferred.
+
     Reference Fields (for documentation, not used by apply())
     ---------------------------------------------------------
     cluster_config : ClusterConfig, optional
@@ -240,12 +252,6 @@ class ClusteringResult:
 
     extremes_config : ExtremeConfig, optional
         Extreme period configuration used to create this result.
-
-    rescale : bool, optional
-        Whether rescaling was enabled when creating this result.
-
-    resolution : float, optional
-        Time resolution of input data in hours.
 
     Examples
     --------
@@ -270,13 +276,15 @@ class ClusteringResult:
     segment_order: tuple[tuple[int, ...], ...] | None = None
     segment_durations: tuple[tuple[int, ...], ...] | None = None
     segment_centers: tuple[tuple[int, ...], ...] | None = None
+    rescale: bool = True
+    representation: RepresentationMethod = "medoid"
+    segment_representation: RepresentationMethod | None = None
+    resolution: float | None = None
 
     # === Reference fields (for documentation, not used by apply()) ===
     cluster_config: ClusterConfig | None = None
     segment_config: SegmentConfig | None = None
     extremes_config: ExtremeConfig | None = None
-    rescale: bool | None = None
-    resolution: float | None = None
 
     def __post_init__(self) -> None:
         if self.segment_order is not None and self.segment_durations is None:
@@ -380,9 +388,12 @@ class ClusteringResult:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
+        # Transfer fields (always included)
         result: dict[str, Any] = {
             "period_hours": self.period_hours,
             "cluster_order": list(self.cluster_order),
+            "rescale": self.rescale,
+            "representation": self.representation,
         }
         if self.cluster_centers is not None:
             result["cluster_centers"] = list(self.cluster_centers)
@@ -392,25 +403,28 @@ class ClusteringResult:
             result["segment_durations"] = [list(s) for s in self.segment_durations]
         if self.segment_centers is not None:
             result["segment_centers"] = [list(s) for s in self.segment_centers]
-        # Parameters used to create this clustering
+        if self.segment_representation is not None:
+            result["segment_representation"] = self.segment_representation
+        if self.resolution is not None:
+            result["resolution"] = self.resolution
+        # Reference fields (optional, for documentation)
         if self.cluster_config is not None:
             result["cluster_config"] = self.cluster_config.to_dict()
         if self.segment_config is not None:
             result["segment_config"] = self.segment_config.to_dict()
         if self.extremes_config is not None:
             result["extremes_config"] = self.extremes_config.to_dict()
-        if self.rescale is not None:
-            result["rescale"] = self.rescale
-        if self.resolution is not None:
-            result["resolution"] = self.resolution
         return result
 
     @classmethod
     def from_dict(cls, data: dict) -> ClusteringResult:
         """Create from dictionary (e.g., loaded from JSON)."""
+        # Transfer fields
         kwargs: dict[str, Any] = {
             "period_hours": data["period_hours"],
             "cluster_order": tuple(data["cluster_order"]),
+            "rescale": data.get("rescale", True),
+            "representation": data.get("representation", "medoid"),
         }
         if "cluster_centers" in data:
             kwargs["cluster_centers"] = tuple(data["cluster_centers"])
@@ -422,17 +436,17 @@ class ClusteringResult:
             )
         if "segment_centers" in data:
             kwargs["segment_centers"] = tuple(tuple(s) for s in data["segment_centers"])
-        # Parameters used to create this clustering
+        if "segment_representation" in data:
+            kwargs["segment_representation"] = data["segment_representation"]
+        if "resolution" in data:
+            kwargs["resolution"] = data["resolution"]
+        # Reference fields
         if "cluster_config" in data:
             kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])
         if "segment_config" in data:
             kwargs["segment_config"] = SegmentConfig.from_dict(data["segment_config"])
         if "extremes_config" in data:
             kwargs["extremes_config"] = ExtremeConfig.from_dict(data["extremes_config"])
-        if "rescale" in data:
-            kwargs["rescale"] = data["rescale"]
-        if "resolution" in data:
-            kwargs["resolution"] = data["resolution"]
         return cls(**kwargs)
 
     def to_json(self, path: str) -> None:
@@ -481,15 +495,13 @@ class ClusteringResult:
         data: pd.DataFrame,
         *,
         resolution: float | None = None,
-        cluster: ClusterConfig | None = None,
-        rescale: bool = True,
         round_decimals: int | None = None,
         numerical_tolerance: float = 1e-13,
     ) -> AggregationResult:
         """Apply this clustering to new data.
 
-        Uses the stored cluster assignments and (optionally) segment assignments
-        to aggregate a different dataset with the same clustering structure.
+        Uses the stored cluster assignments and transfer fields to aggregate
+        a different dataset with the same clustering structure deterministically.
 
         Parameters
         ----------
@@ -499,14 +511,7 @@ class ClusteringResult:
 
         resolution : float, optional
             Time resolution of input data in hours.
-            If not provided, inferred from the datetime index.
-
-        cluster : ClusterConfig, optional
-            Clustering configuration for representation method, weights, etc.
-            The clustering assignments themselves come from this ClusteringResult.
-
-        rescale : bool, default True
-            Rescale typical periods to match the original data's mean.
+            If not provided, uses stored resolution or infers from data index.
 
         round_decimals : int, optional
             Round output values to this many decimal places.
@@ -534,27 +539,32 @@ class ClusteringResult:
         from tsam.result import AccuracyMetrics, AggregationResult
         from tsam.timeseriesaggregation import TimeSeriesAggregation
 
-        # Apply defaults
-        if cluster is None:
-            cluster = ClusterConfig()
+        # Use stored resolution if not provided
+        effective_resolution = resolution if resolution is not None else self.resolution
+
+        # Build cluster config with stored representation
+        cluster = ClusterConfig(representation=self.representation)
 
         # Build segment config if we have segment data
         segments: SegmentConfig | None = None
         n_segments: int | None = None
         if self.segment_order is not None and self.segment_durations is not None:
             n_segments = len(self.segment_durations[0])
-            segments = SegmentConfig(n_segments=n_segments)
+            segments = SegmentConfig(
+                n_segments=n_segments,
+                representation=self.segment_representation or "mean",
+            )
 
         # Build old API parameters, passing predefined values directly
         old_params = _build_old_params(
             data=data,
             n_periods=self.n_periods,
             period_hours=self.period_hours,
-            resolution=resolution,
+            resolution=effective_resolution,
             cluster=cluster,
             segments=segments,
             extremes=None,
-            rescale=rescale,
+            rescale=self.rescale,
             round_decimals=round_decimals,
             numerical_tolerance=numerical_tolerance,
             # Predefined values from this ClusteringResult
@@ -591,21 +601,19 @@ class ClusteringResult:
             rescale_deviations=rescale_deviations,
         )
 
-        # Build ClusteringResult - use stored configs if available
+        # Build ClusteringResult - preserve stored values
         from tsam.api import _build_clustering_result
 
-        effective_rescale = self.rescale if self.rescale is not None else rescale
-        effective_resolution = (
-            self.resolution if self.resolution is not None else resolution
-        )
         clustering_result = _build_clustering_result(
             agg=agg,
             n_segments=n_segments,
-            cluster_config=self.cluster_config or cluster,
-            segment_config=self.segment_config or segments,
-            extremes_config=self.extremes_config,  # Not re-applied, just preserved
-            rescale=effective_rescale,
+            cluster_config=self.cluster_config,
+            segment_config=self.segment_config,
+            extremes_config=self.extremes_config,
+            rescale=self.rescale,
             resolution=effective_resolution,
+            representation=self.representation,
+            segment_representation=self.segment_representation,
         )
 
         # Build result object

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -116,6 +116,36 @@ class ClusterConfig:
         }
         return defaults.get(self.method, "mean")
 
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {"method": self.method}
+        if self.representation is not None:
+            result["representation"] = self.representation
+        if self.weights is not None:
+            result["weights"] = self.weights
+        if self.normalize_means:
+            result["normalize_means"] = self.normalize_means
+        if self.use_duration_curves:
+            result["use_duration_curves"] = self.use_duration_curves
+        if self.include_period_sums:
+            result["include_period_sums"] = self.include_period_sums
+        if self.solver != "highs":
+            result["solver"] = self.solver
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ClusterConfig:
+        """Create from dictionary (e.g., loaded from JSON)."""
+        return cls(
+            method=data.get("method", "hierarchical"),
+            representation=data.get("representation"),
+            weights=data.get("weights"),
+            normalize_means=data.get("normalize_means", False),
+            use_duration_curves=data.get("use_duration_curves", False),
+            include_period_sums=data.get("include_period_sums", False),
+            solver=data.get("solver", "highs"),
+        )
+
 
 @dataclass(frozen=True)
 class SegmentConfig:
@@ -148,6 +178,21 @@ class SegmentConfig:
         # Note: Upper bound validation (n_segments <= timesteps_per_period)
         # is performed in api.aggregate() when period_hours is known.
 
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {"n_segments": self.n_segments}
+        if self.representation != "mean":
+            result["representation"] = self.representation
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SegmentConfig:
+        """Create from dictionary (e.g., loaded from JSON)."""
+        return cls(
+            n_segments=data["n_segments"],
+            representation=data.get("representation", "mean"),
+        )
+
 
 @dataclass(frozen=True)
 class ClusteringResult:
@@ -157,6 +202,7 @@ class ClusteringResult:
     aggregation, enabling:
     - Simple IO via to_json()/from_json()
     - Applying the same clustering to different datasets via apply()
+    - Preserving the parameters used to create the clustering
 
     Get this from `result.clustering` after running an aggregation.
 
@@ -185,6 +231,18 @@ class ClusteringResult:
         Indices of timesteps used as segment centers, per typical period.
         Required for fully deterministic segment replication.
 
+    cluster_config : ClusterConfig, optional
+        Clustering configuration used to create this result.
+        Stored for reference; not used when applying.
+
+    segment_config : SegmentConfig, optional
+        Segmentation configuration used to create this result.
+        Stored for reference; not used when applying.
+
+    rescale : bool, optional
+        Whether rescaling was enabled when creating this result.
+        Default True when applying if not specified.
+
     Examples
     --------
     >>> # Get clustering from a result
@@ -207,6 +265,10 @@ class ClusteringResult:
     segment_order: tuple[tuple[int, ...], ...] | None = None
     segment_durations: tuple[tuple[int, ...], ...] | None = None
     segment_centers: tuple[tuple[int, ...], ...] | None = None
+    # Parameters used to create this clustering (for reference)
+    cluster_config: ClusterConfig | None = None
+    segment_config: SegmentConfig | None = None
+    rescale: bool | None = None
 
     def __post_init__(self) -> None:
         if self.segment_order is not None and self.segment_durations is None:
@@ -322,6 +384,13 @@ class ClusteringResult:
             result["segment_durations"] = [list(s) for s in self.segment_durations]
         if self.segment_centers is not None:
             result["segment_centers"] = [list(s) for s in self.segment_centers]
+        # Parameters used to create this clustering
+        if self.cluster_config is not None:
+            result["cluster_config"] = self.cluster_config.to_dict()
+        if self.segment_config is not None:
+            result["segment_config"] = self.segment_config.to_dict()
+        if self.rescale is not None:
+            result["rescale"] = self.rescale
         return result
 
     @classmethod
@@ -341,6 +410,13 @@ class ClusteringResult:
             )
         if "segment_centers" in data:
             kwargs["segment_centers"] = tuple(tuple(s) for s in data["segment_centers"])
+        # Parameters used to create this clustering
+        if "cluster_config" in data:
+            kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])
+        if "segment_config" in data:
+            kwargs["segment_config"] = SegmentConfig.from_dict(data["segment_config"])
+        if "rescale" in data:
+            kwargs["rescale"] = data["rescale"]
         return cls(**kwargs)
 
     def to_json(self, path: str) -> None:
@@ -500,6 +576,7 @@ class ClusteringResult:
         )
 
         # Build result object
+        # Use stored configs if available, otherwise use what was passed/defaulted
         return AggregationResult(
             typical_periods=typical_periods,
             cluster_assignments=np.array(agg.clusterOrder),
@@ -511,6 +588,9 @@ class ClusteringResult:
             accuracy=accuracy,
             clustering_duration=getattr(agg, "clusteringDuration", 0.0),
             _aggregation=agg,
+            _cluster_config=self.cluster_config or cluster,
+            _segment_config=self.segment_config or segments,
+            _rescale=self.rescale if self.rescale is not None else rescale,
         )
 
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -90,16 +90,6 @@ class ClusterConfig:
     solver : str, default "highs"
         MILP solver for kmedoids method.
         Options: "highs" (default, open source), "cbc", "gurobi", "cplex"
-
-    predef_cluster_order : array-like, optional
-        Predefined cluster assignments for each period.
-        Use this to apply cluster assignments from one aggregation to another.
-        Example: Use wind-only clustering order for multi-variable aggregation.
-
-    predef_cluster_centers : array-like, optional
-        Predefined cluster center indices.
-        When combined with predef_cluster_order, uses the exact same
-        representative periods instead of recalculating them.
     """
 
     method: ClusterMethod = "hierarchical"
@@ -109,8 +99,6 @@ class ClusterConfig:
     use_duration_curves: bool = False
     include_period_sums: bool = False
     solver: Solver = "highs"
-    predef_cluster_order: tuple[int, ...] | None = None
-    predef_cluster_centers: tuple[int, ...] | None = None
 
     def get_representation(self) -> RepresentationMethod:
         """Get the representation method, using default if not specified."""
@@ -149,67 +137,16 @@ class SegmentConfig:
         - "mean": Average value of timesteps in segment
         - "medoid": Actual timestep closest to segment mean
         - "distribution": Preserve distribution within segment
-
-    predef_segment_order : tuple[tuple[int, ...], ...], optional
-        Predefined segment assignments per timestep, per typical period.
-        Use this to transfer segment assignments from one aggregation to another.
-        Outer tuple has one entry per typical period (length = n_periods).
-        Inner tuple has one entry per timestep (length = n_timesteps_per_period),
-        containing the segment index (0 to n_segments-1) for that timestep.
-
-    predef_segment_durations : tuple[tuple[int, ...], ...], optional
-        Predefined durations (in timesteps) per segment, per typical period.
-        Required when predef_segment_order is specified.
-        Outer tuple has one entry per typical period.
-        Inner tuple has one entry per segment, containing the number of
-        timesteps in that segment.
-
-    predef_segment_centers : tuple[tuple[int, ...], ...], optional
-        Predefined center indices per segment, per typical period.
-        When combined with predef_segment_order, uses the exact same
-        segment representatives instead of recalculating them.
-        Outer tuple has one entry per typical period.
-        Inner tuple has one entry per segment, containing the original
-        timestep index (within the period) used as the segment center.
     """
 
     n_segments: int
     representation: RepresentationMethod = "mean"
-    predef_segment_order: tuple[tuple[int, ...], ...] | None = None
-    predef_segment_durations: tuple[tuple[int, ...], ...] | None = None
-    predef_segment_centers: tuple[tuple[int, ...], ...] | None = None
 
     def __post_init__(self) -> None:
         if self.n_segments < 1:
             raise ValueError(f"n_segments must be positive, got {self.n_segments}")
         # Note: Upper bound validation (n_segments <= timesteps_per_period)
         # is performed in api.aggregate() when period_hours is known.
-
-        # Validate predefined segment parameters
-        if self.predef_segment_order is not None:
-            if self.predef_segment_durations is None:
-                raise ValueError(
-                    "predef_segment_durations must be provided when "
-                    "predef_segment_order is specified"
-                )
-            if len(self.predef_segment_order) != len(self.predef_segment_durations):
-                raise ValueError(
-                    f"predef_segment_order ({len(self.predef_segment_order)} periods) "
-                    f"and predef_segment_durations ({len(self.predef_segment_durations)} periods) "
-                    "must have the same number of periods"
-                )
-        elif self.predef_segment_durations is not None:
-            raise ValueError(
-                "predef_segment_order must be provided when "
-                "predef_segment_durations is specified"
-            )
-
-        if self.predef_segment_centers is not None:
-            if self.predef_segment_order is None:
-                raise ValueError(
-                    "predef_segment_order must be provided when "
-                    "predef_segment_centers is specified"
-                )
 
 
 @dataclass(frozen=True)
@@ -509,32 +446,14 @@ class ClusteringResult:
         if cluster is None:
             cluster = ClusterConfig()
 
-        # Override cluster config with our predefined values
-        cluster_kwargs = {
-            "method": cluster.method,
-            "representation": cluster.representation,
-            "weights": cluster.weights,
-            "normalize_means": cluster.normalize_means,
-            "use_duration_curves": cluster.use_duration_curves,
-            "include_period_sums": cluster.include_period_sums,
-            "solver": cluster.solver,
-            "predef_cluster_order": self.cluster_order,
-        }
-        if self.cluster_centers is not None:
-            cluster_kwargs["predef_cluster_centers"] = self.cluster_centers
-        cluster = ClusterConfig(**cluster_kwargs)  # type: ignore[arg-type]
-
         # Build segment config if we have segment data
         segments: SegmentConfig | None = None
+        n_segments: int | None = None
         if self.segment_order is not None and self.segment_durations is not None:
-            segments = SegmentConfig(
-                n_segments=len(self.segment_durations[0]),
-                predef_segment_order=self.segment_order,
-                predef_segment_durations=self.segment_durations,
-                predef_segment_centers=self.segment_centers,
-            )
+            n_segments = len(self.segment_durations[0])
+            segments = SegmentConfig(n_segments=n_segments)
 
-        # Build old API parameters
+        # Build old API parameters, passing predefined values directly
         old_params = _build_old_params(
             data=data,
             n_periods=self.n_periods,
@@ -546,6 +465,12 @@ class ClusteringResult:
             rescale=rescale,
             round_decimals=round_decimals,
             numerical_tolerance=numerical_tolerance,
+            # Predefined values from this ClusteringResult
+            predef_cluster_order=self.cluster_order,
+            predef_cluster_centers=self.cluster_centers,
+            predef_segment_order=self.segment_order,
+            predef_segment_durations=self.segment_durations,
+            predef_segment_centers=self.segment_centers,
         )
 
         # Run aggregation using old implementation
@@ -581,8 +506,8 @@ class ClusteringResult:
             cluster_weights=dict(agg.clusterPeriodNoOccur),
             n_periods=len(agg.clusterPeriodIdx),
             n_timesteps_per_period=agg.timeStepsPerPeriod,
-            n_segments=segments.n_segments if segments else None,
-            segment_durations=agg.segmentDurationDict if segments else None,
+            n_segments=n_segments,
+            segment_durations=agg.segmentDurationDict if n_segments else None,
             cluster_center_indices=np.array(agg.clusterCenterIndices)
             if agg.clusterCenterIndices is not None
             else None,

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
-import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
@@ -239,9 +238,17 @@ class ClusteringResult:
         Segmentation configuration used to create this result.
         Stored for reference; not used when applying.
 
+    extremes_config : ExtremeConfig, optional
+        Extreme period configuration used to create this result.
+        Stored for reference; not used when applying.
+
     rescale : bool, optional
         Whether rescaling was enabled when creating this result.
         Default True when applying if not specified.
+
+    resolution : float, optional
+        Time resolution of input data in hours.
+        Stored for reference; not used when applying.
 
     Examples
     --------
@@ -268,7 +275,9 @@ class ClusteringResult:
     # Parameters used to create this clustering (for reference)
     cluster_config: ClusterConfig | None = None
     segment_config: SegmentConfig | None = None
+    extremes_config: ExtremeConfig | None = None
     rescale: bool | None = None
+    resolution: float | None = None
 
     def __post_init__(self) -> None:
         if self.segment_order is not None and self.segment_durations is None:
@@ -389,8 +398,12 @@ class ClusteringResult:
             result["cluster_config"] = self.cluster_config.to_dict()
         if self.segment_config is not None:
             result["segment_config"] = self.segment_config.to_dict()
+        if self.extremes_config is not None:
+            result["extremes_config"] = self.extremes_config.to_dict()
         if self.rescale is not None:
             result["rescale"] = self.rescale
+        if self.resolution is not None:
+            result["resolution"] = self.resolution
         return result
 
     @classmethod
@@ -415,8 +428,12 @@ class ClusteringResult:
             kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])
         if "segment_config" in data:
             kwargs["segment_config"] = SegmentConfig.from_dict(data["segment_config"])
+        if "extremes_config" in data:
+            kwargs["extremes_config"] = ExtremeConfig.from_dict(data["extremes_config"])
         if "rescale" in data:
             kwargs["rescale"] = data["rescale"]
+        if "resolution" in data:
+            kwargs["resolution"] = data["resolution"]
         return cls(**kwargs)
 
     def to_json(self, path: str) -> None:
@@ -579,22 +596,24 @@ class ClusteringResult:
         from tsam.api import _build_clustering_result
 
         effective_rescale = self.rescale if self.rescale is not None else rescale
+        effective_resolution = (
+            self.resolution if self.resolution is not None else resolution
+        )
         clustering_result = _build_clustering_result(
             agg=agg,
             n_segments=n_segments,
             cluster_config=self.cluster_config or cluster,
             segment_config=self.segment_config or segments,
+            extremes_config=self.extremes_config,  # Not re-applied, just preserved
             rescale=effective_rescale,
+            resolution=effective_resolution,
         )
 
         # Build result object
         return AggregationResult(
             typical_periods=typical_periods,
-            cluster_assignments=np.array(agg.clusterOrder),
             cluster_weights=dict(agg.clusterPeriodNoOccur),
-            n_periods=len(agg.clusterPeriodIdx),
             n_timesteps_per_period=agg.timeStepsPerPeriod,
-            n_segments=n_segments,
             segment_durations=agg.segmentDurationDict if n_segments else None,
             accuracy=accuracy,
             clustering_duration=getattr(agg, "clusteringDuration", 0.0),
@@ -646,6 +665,32 @@ class ExtremeConfig:
         """Check if any extreme periods are configured."""
         return bool(
             self.max_value or self.min_value or self.max_period or self.min_period
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        result: dict[str, Any] = {}
+        if self.method != "append":
+            result["method"] = self.method
+        if self.max_value:
+            result["max_value"] = self.max_value
+        if self.min_value:
+            result["min_value"] = self.min_value
+        if self.max_period:
+            result["max_period"] = self.max_period
+        if self.min_period:
+            result["min_period"] = self.min_period
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ExtremeConfig:
+        """Create from dictionary (e.g., loaded from JSON)."""
+        return cls(
+            method=data.get("method", "append"),
+            max_value=data.get("max_value", []),
+            min_value=data.get("min_value", []),
+            max_period=data.get("max_period", []),
+            min_period=data.get("min_period", []),
         )
 
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -542,15 +542,17 @@ class ClusteringResult:
         # Use stored resolution if not provided
         effective_resolution = resolution if resolution is not None else self.resolution
 
-        # Build cluster config with stored representation
-        cluster = ClusterConfig(representation=self.representation)
+        # Use stored config if available, otherwise build minimal one from transfer fields
+        cluster = self.cluster_config or ClusterConfig(
+            representation=self.representation
+        )
 
-        # Build segment config if we have segment data
+        # Use stored segment config if available, otherwise build from transfer fields
         segments: SegmentConfig | None = None
         n_segments: int | None = None
         if self.segment_order is not None and self.segment_durations is not None:
             n_segments = len(self.segment_durations[0])
-            segments = SegmentConfig(
+            segments = self.segment_config or SegmentConfig(
                 n_segments=n_segments,
                 representation=self.segment_representation or "mean",
             )
@@ -607,13 +609,11 @@ class ClusteringResult:
         clustering_result = _build_clustering_result(
             agg=agg,
             n_segments=n_segments,
-            cluster_config=self.cluster_config,
-            segment_config=self.segment_config,
+            cluster_config=cluster,
+            segment_config=segments,
             extremes_config=self.extremes_config,
             rescale=self.rescale,
             resolution=effective_resolution,
-            representation=self.representation,
-            segment_representation=self.segment_representation,
         )
 
         # Build result object

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -205,8 +205,8 @@ class ClusteringResult:
 
     Get this from `result.clustering` after running an aggregation.
 
-    Parameters
-    ----------
+    Transfer Fields (used by apply())
+    ----------------------------------
     period_hours : int
         Length of each period in hours (e.g., 24 for daily periods).
 
@@ -230,25 +230,22 @@ class ClusteringResult:
         Indices of timesteps used as segment centers, per typical period.
         Required for fully deterministic segment replication.
 
+    Reference Fields (for documentation, not used by apply())
+    ---------------------------------------------------------
     cluster_config : ClusterConfig, optional
         Clustering configuration used to create this result.
-        Stored for reference; not used when applying.
 
     segment_config : SegmentConfig, optional
         Segmentation configuration used to create this result.
-        Stored for reference; not used when applying.
 
     extremes_config : ExtremeConfig, optional
         Extreme period configuration used to create this result.
-        Stored for reference; not used when applying.
 
     rescale : bool, optional
         Whether rescaling was enabled when creating this result.
-        Default True when applying if not specified.
 
     resolution : float, optional
         Time resolution of input data in hours.
-        Stored for reference; not used when applying.
 
     Examples
     --------
@@ -266,13 +263,15 @@ class ClusteringResult:
     >>> result2 = clustering.apply(df_all)
     """
 
+    # === Transfer fields (used by apply()) ===
     period_hours: int
     cluster_order: tuple[int, ...]
     cluster_centers: tuple[int, ...] | None = None
     segment_order: tuple[tuple[int, ...], ...] | None = None
     segment_durations: tuple[tuple[int, ...], ...] | None = None
     segment_centers: tuple[tuple[int, ...], ...] | None = None
-    # Parameters used to create this clustering (for reference)
+
+    # === Reference fields (for documentation, not used by apply()) ===
     cluster_config: ClusterConfig | None = None
     segment_config: SegmentConfig | None = None
     extremes_config: ExtremeConfig | None = None

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
+import numpy as np
 import pandas as pd
+
+if TYPE_CHECKING:
+    from tsam.result import AggregationResult
 
 # Type aliases for clarity
 ClusterMethod = Literal[
@@ -209,11 +213,15 @@ class SegmentConfig:
 
 
 @dataclass(frozen=True)
-class PredefinedConfig:
-    """Predefined assignments for transferring results between aggregations.
+class ClusteringResult:
+    """Clustering assignments that can be saved/loaded and applied to new data.
 
-    Use this to apply clustering and segmentation results from one aggregation
-    to another dataset. Get this from `result.predefined` or create manually.
+    This class bundles all clustering and segmentation assignments from an
+    aggregation, enabling:
+    - Simple IO via to_json()/from_json()
+    - Applying the same clustering to different datasets via apply()
+
+    Get this from `result.clustering` after running an aggregation.
 
     Parameters
     ----------
@@ -223,33 +231,30 @@ class PredefinedConfig:
 
     cluster_centers : tuple[int, ...], optional
         Indices of original periods used as cluster centers.
-        If not provided, centers will be recalculated.
+        If not provided, centers will be recalculated when applying.
 
     segment_order : tuple[tuple[int, ...], ...], optional
         Segment assignments per timestep, per typical period.
-        Only needed if transferring segmentation results.
+        Only present if segmentation was used.
 
     segment_durations : tuple[tuple[int, ...], ...], optional
         Duration (in timesteps) per segment, per typical period.
-        Required if segment_order is provided.
+        Required if segment_order is present.
 
     Examples
     --------
-    >>> # From a previous result
-    >>> predefined = result.predefined
+    >>> # Get clustering from a result
+    >>> result = tsam.aggregate(df_wind, n_periods=8)
+    >>> clustering = result.clustering
 
     >>> # Save to file
-    >>> import json
-    >>> with open("predefined.json", "w") as f:
-    ...     json.dump(predefined.to_dict(), f)
+    >>> clustering.to_json("clustering.json")
 
     >>> # Load from file
-    >>> with open("predefined.json") as f:
-    ...     data = json.load(f)
-    >>> predefined = PredefinedConfig.from_dict(data)
+    >>> clustering = ClusteringResult.from_json("clustering.json")
 
     >>> # Apply to new data
-    >>> result2 = tsam.aggregate(new_data, n_periods=8, predefined=predefined)
+    >>> result2 = clustering.apply(df_all)
     """
 
     cluster_order: tuple[int, ...]
@@ -267,16 +272,31 @@ class PredefinedConfig:
                 "segment_order must be provided when segment_durations is specified"
             )
 
+    @property
+    def n_periods(self) -> int:
+        """Number of typical periods (clusters)."""
+        return len(set(self.cluster_order))
+
+    @property
+    def n_original_periods(self) -> int:
+        """Number of original periods in the source data."""
+        return len(self.cluster_order)
+
+    @property
+    def n_segments(self) -> int | None:
+        """Number of segments per period, or None if no segmentation."""
+        if self.segment_durations is None:
+            return None
+        return len(self.segment_durations[0])
+
     def __repr__(self) -> str:
-        n_original_periods = len(self.cluster_order)
-        n_typical_periods = len(set(self.cluster_order))
         has_centers = self.cluster_centers is not None
         has_segments = self.segment_order is not None
 
         lines = [
-            "PredefinedConfig(",
-            f"  n_original_periods={n_original_periods},",
-            f"  n_typical_periods={n_typical_periods},",
+            "ClusteringResult(",
+            f"  n_original_periods={self.n_original_periods},",
+            f"  n_periods={self.n_periods},",
             f"  has_cluster_centers={has_centers},",
         ]
 
@@ -293,23 +313,19 @@ class PredefinedConfig:
         """Convert to a readable DataFrame.
 
         Returns a DataFrame with one row per original period showing
-        cluster assignments. If segments are defined, includes segment
-        information for each typical period.
+        cluster assignments.
 
         Returns
         -------
         pd.DataFrame
             DataFrame with cluster_order indexed by original period.
-            If segments are present, includes additional columns.
         """
-        # Base DataFrame with cluster assignments
         df = pd.DataFrame(
             {"cluster": list(self.cluster_order)},
             index=pd.RangeIndex(len(self.cluster_order), name="original_period"),
         )
 
         if self.cluster_centers is not None:
-            # Add a column showing which periods are cluster centers
             center_set = set(self.cluster_centers)
             df["is_center"] = [i in center_set for i in range(len(self.cluster_order))]
 
@@ -351,9 +367,9 @@ class PredefinedConfig:
         return result
 
     @classmethod
-    def from_dict(cls, data: dict) -> PredefinedConfig:
+    def from_dict(cls, data: dict) -> ClusteringResult:
         """Create from dictionary (e.g., loaded from JSON)."""
-        kwargs = {"cluster_order": tuple(data["cluster_order"])}
+        kwargs: dict[str, Any] = {"cluster_order": tuple(data["cluster_order"])}
         if "cluster_centers" in data:
             kwargs["cluster_centers"] = tuple(data["cluster_centers"])
         if "segment_order" in data:
@@ -363,6 +379,194 @@ class PredefinedConfig:
                 tuple(s) for s in data["segment_durations"]
             )
         return cls(**kwargs)
+
+    def to_json(self, path: str) -> None:
+        """Save clustering result to a JSON file.
+
+        Parameters
+        ----------
+        path : str
+            File path to save to.
+
+        Examples
+        --------
+        >>> result.clustering.to_json("clustering.json")
+        """
+        import json
+
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+    @classmethod
+    def from_json(cls, path: str) -> ClusteringResult:
+        """Load clustering result from a JSON file.
+
+        Parameters
+        ----------
+        path : str
+            File path to load from.
+
+        Returns
+        -------
+        ClusteringResult
+            Loaded clustering result.
+
+        Examples
+        --------
+        >>> clustering = ClusteringResult.from_json("clustering.json")
+        >>> result = clustering.apply(new_data)
+        """
+        import json
+
+        with open(path) as f:
+            return cls.from_dict(json.load(f))
+
+    def apply(
+        self,
+        data: pd.DataFrame,
+        *,
+        period_hours: int = 24,
+        resolution: float | None = None,
+        cluster: ClusterConfig | None = None,
+        rescale: bool = True,
+        round_decimals: int | None = None,
+        numerical_tolerance: float = 1e-13,
+    ) -> AggregationResult:
+        """Apply this clustering to new data.
+
+        Uses the stored cluster assignments and (optionally) segment assignments
+        to aggregate a different dataset with the same clustering structure.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            Input time series data with a datetime index.
+            Must have the same number of periods as the original data.
+
+        period_hours : int, default 24
+            Length of each period in hours.
+
+        resolution : float, optional
+            Time resolution of input data in hours.
+            If not provided, inferred from the datetime index.
+
+        cluster : ClusterConfig, optional
+            Clustering configuration for representation method, weights, etc.
+            The clustering assignments themselves come from this ClusteringResult.
+
+        rescale : bool, default True
+            Rescale typical periods to match the original data's mean.
+
+        round_decimals : int, optional
+            Round output values to this many decimal places.
+
+        numerical_tolerance : float, default 1e-13
+            Tolerance for numerical precision issues.
+
+        Returns
+        -------
+        AggregationResult
+            Aggregation result using this clustering.
+
+        Examples
+        --------
+        >>> # Cluster on wind data, apply to full dataset
+        >>> result_wind = tsam.aggregate(df_wind, n_periods=8)
+        >>> result_all = result_wind.clustering.apply(df_all)
+
+        >>> # Load saved clustering and apply
+        >>> clustering = ClusteringResult.from_json("clustering.json")
+        >>> result = clustering.apply(df)
+        """
+        # Import here to avoid circular imports
+        from tsam.api import _build_old_params
+        from tsam.result import AccuracyMetrics, AggregationResult
+        from tsam.timeseriesaggregation import TimeSeriesAggregation
+
+        # Apply defaults
+        if cluster is None:
+            cluster = ClusterConfig()
+
+        # Override cluster config with our predefined values
+        cluster_kwargs = {
+            "method": cluster.method,
+            "representation": cluster.representation,
+            "weights": cluster.weights,
+            "normalize_means": cluster.normalize_means,
+            "use_duration_curves": cluster.use_duration_curves,
+            "include_period_sums": cluster.include_period_sums,
+            "solver": cluster.solver,
+            "predef_cluster_order": self.cluster_order,
+        }
+        if self.cluster_centers is not None:
+            cluster_kwargs["predef_cluster_centers"] = self.cluster_centers
+        cluster = ClusterConfig(**cluster_kwargs)  # type: ignore[arg-type]
+
+        # Build segment config if we have segment data
+        segments: SegmentConfig | None = None
+        if self.segment_order is not None and self.segment_durations is not None:
+            segments = SegmentConfig(
+                n_segments=len(self.segment_durations[0]),
+                predef_segment_order=self.segment_order,
+                predef_segment_durations=self.segment_durations,
+            )
+
+        # Build old API parameters
+        old_params = _build_old_params(
+            data=data,
+            n_periods=self.n_periods,
+            period_hours=period_hours,
+            resolution=resolution,
+            cluster=cluster,
+            segments=segments,
+            extremes=None,
+            rescale=rescale,
+            round_decimals=round_decimals,
+            numerical_tolerance=numerical_tolerance,
+        )
+
+        # Run aggregation using old implementation
+        agg = TimeSeriesAggregation(**old_params)
+        typical_periods = agg.createTypicalPeriods()
+
+        # Build accuracy metrics
+        accuracy_df = agg.accuracyIndicators()
+
+        # Build rescale deviations DataFrame
+        rescale_deviations_dict = getattr(agg, "_rescaleDeviations", {})
+        if rescale_deviations_dict:
+            rescale_deviations = pd.DataFrame.from_dict(
+                rescale_deviations_dict, orient="index"
+            )
+            rescale_deviations.index.name = "column"
+        else:
+            rescale_deviations = pd.DataFrame(
+                columns=["deviation_pct", "converged", "iterations"]
+            )
+
+        accuracy = AccuracyMetrics(
+            rmse=accuracy_df["RMSE"],
+            mae=accuracy_df["MAE"],
+            rmse_duration=accuracy_df["RMSE_duration"],
+            rescale_deviations=rescale_deviations,
+        )
+
+        # Build result object
+        return AggregationResult(
+            typical_periods=typical_periods,
+            cluster_assignments=np.array(agg.clusterOrder),
+            cluster_weights=dict(agg.clusterPeriodNoOccur),
+            n_periods=len(agg.clusterPeriodIdx),
+            n_timesteps_per_period=agg.timeStepsPerPeriod,
+            n_segments=segments.n_segments if segments else None,
+            segment_durations=agg.segmentDurationDict if segments else None,
+            cluster_center_indices=np.array(agg.clusterCenterIndices)
+            if agg.clusterCenterIndices is not None
+            else None,
+            accuracy=accuracy,
+            clustering_duration=getattr(agg, "clusteringDuration", 0.0),
+            _aggregation=agg,
+        )
 
 
 @dataclass(frozen=True)

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -225,6 +225,9 @@ class ClusteringResult:
 
     Parameters
     ----------
+    period_hours : int
+        Length of each period in hours (e.g., 24 for daily periods).
+
     cluster_order : tuple[int, ...]
         Cluster assignments for each original period.
         Length equals the number of original periods in the data.
@@ -240,6 +243,10 @@ class ClusteringResult:
     segment_durations : tuple[tuple[int, ...], ...], optional
         Duration (in timesteps) per segment, per typical period.
         Required if segment_order is present.
+
+    segment_centers : tuple[tuple[int, ...], ...], optional
+        Indices of timesteps used as segment centers, per typical period.
+        Required for fully deterministic segment replication.
 
     Examples
     --------
@@ -257,10 +264,12 @@ class ClusteringResult:
     >>> result2 = clustering.apply(df_all)
     """
 
+    period_hours: int
     cluster_order: tuple[int, ...]
     cluster_centers: tuple[int, ...] | None = None
     segment_order: tuple[tuple[int, ...], ...] | None = None
     segment_durations: tuple[tuple[int, ...], ...] | None = None
+    segment_centers: tuple[tuple[int, ...], ...] | None = None
 
     def __post_init__(self) -> None:
         if self.segment_order is not None and self.segment_durations is None:
@@ -270,6 +279,10 @@ class ClusteringResult:
         if self.segment_durations is not None and self.segment_order is None:
             raise ValueError(
                 "segment_order must be provided when segment_durations is specified"
+            )
+        if self.segment_centers is not None and self.segment_order is None:
+            raise ValueError(
+                "segment_order must be provided when segment_centers is specified"
             )
 
     @property
@@ -295,6 +308,7 @@ class ClusteringResult:
 
         lines = [
             "ClusteringResult(",
+            f"  period_hours={self.period_hours},",
             f"  n_original_periods={self.n_original_periods},",
             f"  n_periods={self.n_periods},",
             f"  has_cluster_centers={has_centers},",
@@ -303,8 +317,10 @@ class ClusteringResult:
         if has_segments:
             n_segments = len(self.segment_durations[0]) if self.segment_durations else 0
             n_timesteps = len(self.segment_order[0]) if self.segment_order else 0
+            has_seg_centers = self.segment_centers is not None
             lines.append(f"  n_segments={n_segments},")
             lines.append(f"  n_timesteps_per_period={n_timesteps},")
+            lines.append(f"  has_segment_centers={has_seg_centers},")
 
         lines.append(")")
         return "\n".join(lines)
@@ -357,19 +373,27 @@ class ClusteringResult:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization."""
-        result: dict[str, Any] = {"cluster_order": list(self.cluster_order)}
+        result: dict[str, Any] = {
+            "period_hours": self.period_hours,
+            "cluster_order": list(self.cluster_order),
+        }
         if self.cluster_centers is not None:
             result["cluster_centers"] = list(self.cluster_centers)
         if self.segment_order is not None:
             result["segment_order"] = [list(s) for s in self.segment_order]
         if self.segment_durations is not None:
             result["segment_durations"] = [list(s) for s in self.segment_durations]
+        if self.segment_centers is not None:
+            result["segment_centers"] = [list(s) for s in self.segment_centers]
         return result
 
     @classmethod
     def from_dict(cls, data: dict) -> ClusteringResult:
         """Create from dictionary (e.g., loaded from JSON)."""
-        kwargs: dict[str, Any] = {"cluster_order": tuple(data["cluster_order"])}
+        kwargs: dict[str, Any] = {
+            "period_hours": data["period_hours"],
+            "cluster_order": tuple(data["cluster_order"]),
+        }
         if "cluster_centers" in data:
             kwargs["cluster_centers"] = tuple(data["cluster_centers"])
         if "segment_order" in data:
@@ -378,6 +402,8 @@ class ClusteringResult:
             kwargs["segment_durations"] = tuple(
                 tuple(s) for s in data["segment_durations"]
             )
+        if "segment_centers" in data:
+            kwargs["segment_centers"] = tuple(tuple(s) for s in data["segment_centers"])
         return cls(**kwargs)
 
     def to_json(self, path: str) -> None:
@@ -425,7 +451,6 @@ class ClusteringResult:
         self,
         data: pd.DataFrame,
         *,
-        period_hours: int = 24,
         resolution: float | None = None,
         cluster: ClusterConfig | None = None,
         rescale: bool = True,
@@ -442,9 +467,6 @@ class ClusteringResult:
         data : pd.DataFrame
             Input time series data with a datetime index.
             Must have the same number of periods as the original data.
-
-        period_hours : int, default 24
-            Length of each period in hours.
 
         resolution : float, optional
             Time resolution of input data in hours.
@@ -509,13 +531,14 @@ class ClusteringResult:
                 n_segments=len(self.segment_durations[0]),
                 predef_segment_order=self.segment_order,
                 predef_segment_durations=self.segment_durations,
+                predef_segment_centers=self.segment_centers,
             )
 
         # Build old API parameters
         old_params = _build_old_params(
             data=data,
             n_periods=self.n_periods,
-            period_hours=period_hours,
+            period_hours=self.period_hours,
             resolution=resolution,
             cluster=cluster,
             segments=segments,

--- a/src/tsam/plot.py
+++ b/src/tsam/plot.py
@@ -628,6 +628,48 @@ class ResultPlotAccessor:
 
         return fig
 
+    def cluster_assignments(
+        self,
+        title: str = "Cluster Assignments",
+        color_continuous_scale: str = "Viridis",
+    ) -> go.Figure:
+        """Plot which cluster each original period was assigned to.
+
+        Shows a heatmap visualization of the cluster assignment for each
+        original period in the dataset.
+
+        Parameters
+        ----------
+        title : str, default "Cluster Assignments"
+            Plot title.
+        color_continuous_scale : str, default "Viridis"
+            Plotly color scale name.
+
+        Returns
+        -------
+        go.Figure
+
+        Examples
+        --------
+        >>> result = tsam.aggregate(df, n_periods=8)
+        >>> result.plot.cluster_assignments()
+        """
+        assignments = self._result.cluster_assignments
+
+        fig = px.imshow(
+            [assignments],
+            labels={"x": "Original Period", "color": "Cluster"},
+            title=title,
+            color_continuous_scale=color_continuous_scale,
+            aspect="auto",
+        )
+        fig.update_layout(
+            yaxis={"visible": False},
+            coloraxis_colorbar={"dtick": 1},
+        )
+
+        return fig
+
     def accuracy(self, title: str = "Accuracy Metrics") -> go.Figure:
         """Plot accuracy metrics by column.
 

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -117,16 +118,32 @@ class AggregationResult:
     """
 
     typical_periods: pd.DataFrame
-    cluster_assignments: np.ndarray
     cluster_weights: dict[int, int]
-    n_periods: int
     n_timesteps_per_period: int
-    n_segments: int | None
     segment_durations: dict[int, float] | None
     accuracy: AccuracyMetrics
     clustering_duration: float
     clustering: ClusteringResult
     _aggregation: TimeSeriesAggregation = field(repr=False, compare=False)
+
+    @cached_property
+    def n_periods(self) -> int:
+        """Number of typical periods (clusters)."""
+        return self.clustering.n_periods
+
+    @cached_property
+    def n_segments(self) -> int | None:
+        """Number of segments per period if segmentation was used, else None."""
+        return self.clustering.n_segments
+
+    @cached_property
+    def cluster_assignments(self) -> np.ndarray:
+        """Which cluster each original period belongs to.
+
+        Length equals the number of original periods.
+        Values are cluster indices (0 to n_periods-1).
+        """
+        return np.array(self.clustering.cluster_order)
 
     def __repr__(self) -> str:
         seg_info = f", n_segments={self.n_segments}" if self.n_segments else ""

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -170,6 +170,7 @@ class AggregationResult:
         dict
             Dictionary containing all result data in serializable format.
         """
+        clustering = self.clustering
         return {
             "typical_periods": self.typical_periods.to_dict(),
             "cluster_assignments": self.cluster_assignments.tolist(),
@@ -178,8 +179,8 @@ class AggregationResult:
             "n_timesteps_per_period": self.n_timesteps_per_period,
             "n_segments": self.n_segments,
             "segment_durations": self.segment_durations,
-            "segment_assignments": self.segment_assignments,
-            "segment_durations_tuple": self.segment_durations_tuple,
+            "segment_assignments": clustering.segment_order,
+            "segment_durations_tuple": clustering.segment_durations,
             "cluster_center_indices": self.cluster_center_indices.tolist()
             if self.cluster_center_indices is not None
             else None,
@@ -293,91 +294,6 @@ class AggregationResult:
         return result_df
 
     @property
-    def segment_assignments(self) -> tuple[tuple[int, ...], ...] | None:
-        """Get segment assignments per typical period.
-
-        Returns the segment index for each timestep within each typical period.
-        This is included in `result.clustering` for transfer to other data.
-
-        Returns
-        -------
-        tuple[tuple[int, ...], ...] | None
-            Tuple of tuples, one per typical period. Each inner tuple contains
-            segment indices (0 to n_segments-1) for each timestep in that period.
-            Returns None if segmentation was not used.
-
-        Examples
-        --------
-        >>> result = tsam.aggregate(df, n_periods=8, segments=SegmentConfig(n_segments=6))
-        >>> result.segment_assignments[0]
-        (0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5)
-
-        >>> # Transfer to another dataset using ClusteringResult
-        >>> result2 = result.clustering.apply(other_data)
-        """
-        if self.n_segments is None:
-            return None
-
-        agg = self._aggregation
-        if not hasattr(agg, "segmentedNormalizedTypicalPeriods"):
-            return None
-
-        result = []
-        segmented_df = agg.segmentedNormalizedTypicalPeriods
-
-        for period_idx in segmented_df.index.get_level_values(0).unique():
-            period_data = segmented_df.loc[period_idx]
-            # Reconstruct full assignment from segment structure
-            # Index levels: Segment Step, Segment Duration, Original Start Step
-            assignments = []
-            for seg_step, seg_dur, _orig_start in period_data.index:
-                assignments.extend([int(seg_step)] * int(seg_dur))
-            result.append(tuple(assignments))
-
-        return tuple(result)
-
-    @property
-    def segment_durations_tuple(self) -> tuple[tuple[int, ...], ...] | None:
-        """Get segment durations per typical period.
-
-        Returns the duration (number of timesteps) for each segment within
-        each typical period. This is included in `result.clustering` for
-        transfer to other data.
-
-        Returns
-        -------
-        tuple[tuple[int, ...], ...] | None
-            Tuple of tuples, one per typical period. Each inner tuple contains
-            the duration (in timesteps) of each segment.
-            Returns None if segmentation was not used.
-
-        Examples
-        --------
-        >>> result = tsam.aggregate(df, n_periods=8, segments=SegmentConfig(n_segments=6))
-        >>> result.segment_durations_tuple[0]
-        (4, 3, 4, 3, 4, 6)  # 6 segments with varying lengths summing to 24
-        """
-        if self.n_segments is None:
-            return None
-
-        agg = self._aggregation
-        if not hasattr(agg, "segmentedNormalizedTypicalPeriods"):
-            return None
-
-        result = []
-        segmented_df = agg.segmentedNormalizedTypicalPeriods
-
-        for period_idx in segmented_df.index.get_level_values(0).unique():
-            period_data = segmented_df.loc[period_idx]
-            # Index levels: Segment Step, Segment Duration, Original Start Step
-            durations = tuple(
-                int(seg_dur) for _seg_step, seg_dur, _orig_start in period_data.index
-            )
-            result.append(durations)
-
-        return tuple(result)
-
-    @property
     def clustering(self) -> ClusteringResult:
         """Get clustering result for saving or applying to new data.
 
@@ -407,14 +323,39 @@ class AggregationResult:
         """
         from tsam.config import ClusteringResult
 
+        # Compute segment data if segmentation was used
+        segment_order: tuple[tuple[int, ...], ...] | None = None
+        segment_durations: tuple[tuple[int, ...], ...] | None = None
+
+        if self.n_segments is not None:
+            agg = self._aggregation
+            if hasattr(agg, "segmentedNormalizedTypicalPeriods"):
+                segmented_df = agg.segmentedNormalizedTypicalPeriods
+                segment_order_list = []
+                segment_durations_list = []
+
+                for period_idx in segmented_df.index.get_level_values(0).unique():
+                    period_data = segmented_df.loc[period_idx]
+                    # Index levels: Segment Step, Segment Duration, Original Start Step
+                    assignments = []
+                    durations = []
+                    for seg_step, seg_dur, _orig_start in period_data.index:
+                        assignments.extend([int(seg_step)] * int(seg_dur))
+                        durations.append(int(seg_dur))
+                    segment_order_list.append(tuple(assignments))
+                    segment_durations_list.append(tuple(durations))
+
+                segment_order = tuple(segment_order_list)
+                segment_durations = tuple(segment_durations_list)
+
         return ClusteringResult(
             period_hours=self._aggregation.hoursPerPeriod,
             cluster_order=tuple(self.cluster_assignments.tolist()),
             cluster_centers=tuple(self.cluster_center_indices.tolist())
             if self.cluster_center_indices is not None
             else None,
-            segment_order=self.segment_assignments,
-            segment_durations=self.segment_durations_tuple,
+            segment_order=segment_order,
+            segment_durations=segment_durations,
             segment_centers=None,  # Not currently captured by segmentation
         )
 

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -294,11 +294,10 @@ class AggregationResult:
 
     @property
     def segment_assignments(self) -> tuple[tuple[int, ...], ...] | None:
-        """Get segment assignments per typical period for transfer.
+        """Get segment assignments per typical period.
 
         Returns the segment index for each timestep within each typical period.
-        This can be passed to another aggregation's SegmentConfig.predef_segment_order
-        to reproduce the same segmentation.
+        This is included in `result.clustering` for transfer to other data.
 
         Returns
         -------
@@ -313,15 +312,8 @@ class AggregationResult:
         >>> result.segment_assignments[0]
         (0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5)
 
-        >>> # Transfer to another aggregation
-        >>> result2 = tsam.aggregate(
-        ...     other_data,
-        ...     segments=SegmentConfig(
-        ...         n_segments=6,
-        ...         predef_segment_order=result.segment_assignments,
-        ...         predef_segment_durations=result.segment_durations_tuple,
-        ...     ),
-        ... )
+        >>> # Transfer to another dataset using ClusteringResult
+        >>> result2 = result.clustering.apply(other_data)
         """
         if self.n_segments is None:
             return None
@@ -346,11 +338,11 @@ class AggregationResult:
 
     @property
     def segment_durations_tuple(self) -> tuple[tuple[int, ...], ...] | None:
-        """Get segment durations per typical period for transfer.
+        """Get segment durations per typical period.
 
         Returns the duration (number of timesteps) for each segment within
-        each typical period. This can be passed to another aggregation's
-        SegmentConfig.predef_segment_durations to reproduce the same segmentation.
+        each typical period. This is included in `result.clustering` for
+        transfer to other data.
 
         Returns
         -------

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
@@ -90,10 +91,6 @@ class AggregationResult:
         Duration of each segment if segmentation was used.
         Keys are segment indices, values are durations in hours.
 
-    cluster_center_indices : np.ndarray
-        Indices of original periods used as cluster centers.
-        These are the "representative" periods for each cluster.
-
     accuracy : AccuracyMetrics
         Accuracy metrics comparing reconstructed to original data.
 
@@ -127,7 +124,6 @@ class AggregationResult:
     n_timesteps_per_period: int
     n_segments: int | None
     segment_durations: dict[int, float] | None
-    cluster_center_indices: np.ndarray | None
     accuracy: AccuracyMetrics
     clustering_duration: float
     _aggregation: TimeSeriesAggregation = field(repr=False, compare=False)
@@ -170,7 +166,6 @@ class AggregationResult:
         dict
             Dictionary containing all result data in serializable format.
         """
-        clustering = self.clustering
         return {
             "typical_periods": self.typical_periods.to_dict(),
             "cluster_assignments": self.cluster_assignments.tolist(),
@@ -179,11 +174,7 @@ class AggregationResult:
             "n_timesteps_per_period": self.n_timesteps_per_period,
             "n_segments": self.n_segments,
             "segment_durations": self.segment_durations,
-            "segment_assignments": clustering.segment_order,
-            "segment_durations_tuple": clustering.segment_durations,
-            "cluster_center_indices": self.cluster_center_indices.tolist()
-            if self.cluster_center_indices is not None
-            else None,
+            "clustering": self.clustering.to_dict(),
             "accuracy": {
                 "rmse": self.accuracy.rmse.to_dict(),
                 "mae": self.accuracy.mae.to_dict(),
@@ -293,12 +284,13 @@ class AggregationResult:
 
         return result_df
 
-    @property
+    @cached_property
     def clustering(self) -> ClusteringResult:
         """Get clustering result for saving or applying to new data.
 
         Returns a ClusteringResult containing all assignment information that
-        can be saved to disk and/or applied to different datasets.
+        can be saved to disk and/or applied to different datasets. This property
+        is cached for efficiency.
 
         Returns
         -------
@@ -323,12 +315,18 @@ class AggregationResult:
         """
         from tsam.config import ClusteringResult
 
+        agg = self._aggregation
+
+        # Get cluster centers from aggregation (convert to Python ints for JSON serialization)
+        cluster_centers: tuple[int, ...] | None = None
+        if agg.clusterCenterIndices is not None:
+            cluster_centers = tuple(int(x) for x in agg.clusterCenterIndices)
+
         # Compute segment data if segmentation was used
         segment_order: tuple[tuple[int, ...], ...] | None = None
         segment_durations: tuple[tuple[int, ...], ...] | None = None
 
         if self.n_segments is not None:
-            agg = self._aggregation
             if hasattr(agg, "segmentedNormalizedTypicalPeriods"):
                 segmented_df = agg.segmentedNormalizedTypicalPeriods
                 segment_order_list = []
@@ -349,11 +347,9 @@ class AggregationResult:
                 segment_durations = tuple(segment_durations_list)
 
         return ClusteringResult(
-            period_hours=self._aggregation.hoursPerPeriod,
+            period_hours=agg.hoursPerPeriod,
             cluster_order=tuple(self.cluster_assignments.tolist()),
-            cluster_centers=tuple(self.cluster_center_indices.tolist())
-            if self.cluster_center_indices is not None
-            else None,
+            cluster_centers=cluster_centers,
             segment_order=segment_order,
             segment_durations=segment_durations,
             segment_centers=None,  # Not currently captured by segmentation

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
-    from tsam.config import ClusteringResult
+    from tsam.config import ClusterConfig, ClusteringResult, SegmentConfig
     from tsam.plot import ResultPlotAccessor
     from tsam.timeseriesaggregation import TimeSeriesAggregation
 
@@ -127,6 +127,14 @@ class AggregationResult:
     accuracy: AccuracyMetrics
     clustering_duration: float
     _aggregation: TimeSeriesAggregation = field(repr=False, compare=False)
+    # Parameters used (for ClusteringResult)
+    _cluster_config: ClusterConfig | None = field(
+        default=None, repr=False, compare=False
+    )
+    _segment_config: SegmentConfig | None = field(
+        default=None, repr=False, compare=False
+    )
+    _rescale: bool = field(default=True, repr=False, compare=False)
 
     def __repr__(self) -> str:
         seg_info = f", n_segments={self.n_segments}" if self.n_segments else ""
@@ -353,6 +361,9 @@ class AggregationResult:
             segment_order=segment_order,
             segment_durations=segment_durations,
             segment_centers=None,  # Not currently captured by segmentation
+            cluster_config=self._cluster_config,
+            segment_config=self._segment_config,
+            rescale=self._rescale,
         )
 
     @property

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from functools import cached_property
 from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
-    from tsam.config import ClusterConfig, ClusteringResult, SegmentConfig
+    from tsam.config import ClusteringResult
     from tsam.plot import ResultPlotAccessor
     from tsam.timeseriesaggregation import TimeSeriesAggregation
 
@@ -126,15 +125,8 @@ class AggregationResult:
     segment_durations: dict[int, float] | None
     accuracy: AccuracyMetrics
     clustering_duration: float
+    clustering: ClusteringResult
     _aggregation: TimeSeriesAggregation = field(repr=False, compare=False)
-    # Parameters used (for ClusteringResult)
-    _cluster_config: ClusterConfig | None = field(
-        default=None, repr=False, compare=False
-    )
-    _segment_config: SegmentConfig | None = field(
-        default=None, repr=False, compare=False
-    )
-    _rescale: bool = field(default=True, repr=False, compare=False)
 
     def __repr__(self) -> str:
         seg_info = f", n_segments={self.n_segments}" if self.n_segments else ""
@@ -291,80 +283,6 @@ class AggregationResult:
             result_df["segment_idx"] = segment_indices
 
         return result_df
-
-    @cached_property
-    def clustering(self) -> ClusteringResult:
-        """Get clustering result for saving or applying to new data.
-
-        Returns a ClusteringResult containing all assignment information that
-        can be saved to disk and/or applied to different datasets. This property
-        is cached for efficiency.
-
-        Returns
-        -------
-        ClusteringResult
-            Object with period_hours, cluster_order, cluster_centers (optional),
-            segment_order (if segmentation), segment_durations (if segmentation),
-            segment_centers (if available).
-
-        Examples
-        --------
-        >>> result = tsam.aggregate(df, n_periods=8)
-
-        >>> # Apply to new data
-        >>> result2 = result.clustering.apply(new_data)
-
-        >>> # Save to file
-        >>> result.clustering.to_json("clustering.json")
-
-        >>> # Load and apply
-        >>> clustering = ClusteringResult.from_json("clustering.json")
-        >>> result2 = clustering.apply(new_data)
-        """
-        from tsam.config import ClusteringResult
-
-        agg = self._aggregation
-
-        # Get cluster centers from aggregation (convert to Python ints for JSON serialization)
-        cluster_centers: tuple[int, ...] | None = None
-        if agg.clusterCenterIndices is not None:
-            cluster_centers = tuple(int(x) for x in agg.clusterCenterIndices)
-
-        # Compute segment data if segmentation was used
-        segment_order: tuple[tuple[int, ...], ...] | None = None
-        segment_durations: tuple[tuple[int, ...], ...] | None = None
-
-        if self.n_segments is not None:
-            if hasattr(agg, "segmentedNormalizedTypicalPeriods"):
-                segmented_df = agg.segmentedNormalizedTypicalPeriods
-                segment_order_list = []
-                segment_durations_list = []
-
-                for period_idx in segmented_df.index.get_level_values(0).unique():
-                    period_data = segmented_df.loc[period_idx]
-                    # Index levels: Segment Step, Segment Duration, Original Start Step
-                    assignments = []
-                    durations = []
-                    for seg_step, seg_dur, _orig_start in period_data.index:
-                        assignments.extend([int(seg_step)] * int(seg_dur))
-                        durations.append(int(seg_dur))
-                    segment_order_list.append(tuple(assignments))
-                    segment_durations_list.append(tuple(durations))
-
-                segment_order = tuple(segment_order_list)
-                segment_durations = tuple(segment_durations_list)
-
-        return ClusteringResult(
-            period_hours=agg.hoursPerPeriod,
-            cluster_order=tuple(self.cluster_assignments.tolist()),
-            cluster_centers=cluster_centers,
-            segment_order=segment_order,
-            segment_durations=segment_durations,
-            segment_centers=None,  # Not currently captured by segmentation
-            cluster_config=self._cluster_config,
-            segment_config=self._segment_config,
-            rescale=self._rescale,
-        )
 
     @property
     def plot(self) -> ResultPlotAccessor:

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -395,8 +395,9 @@ class AggregationResult:
         Returns
         -------
         ClusteringResult
-            Object with cluster_order, cluster_centers (optional),
-            segment_order (if segmentation), segment_durations (if segmentation).
+            Object with period_hours, cluster_order, cluster_centers (optional),
+            segment_order (if segmentation), segment_durations (if segmentation),
+            segment_centers (if available).
 
         Examples
         --------
@@ -415,12 +416,14 @@ class AggregationResult:
         from tsam.config import ClusteringResult
 
         return ClusteringResult(
+            period_hours=self._aggregation.hoursPerPeriod,
             cluster_order=tuple(self.cluster_assignments.tolist()),
             cluster_centers=tuple(self.cluster_center_indices.tolist())
             if self.cluster_center_indices is not None
             else None,
             segment_order=self.segment_assignments,
             segment_durations=self.segment_durations_tuple,
+            segment_centers=None,  # Not currently captured by segmentation
         )
 
     @property

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
-    from tsam.config import PredefinedConfig
+    from tsam.config import ClusteringResult
     from tsam.plot import ResultPlotAccessor
     from tsam.timeseriesaggregation import TimeSeriesAggregation
 
@@ -386,38 +386,35 @@ class AggregationResult:
         return tuple(result)
 
     @property
-    def predefined(self) -> PredefinedConfig:
-        """Get predefined state for transferring to another aggregation.
+    def clustering(self) -> ClusteringResult:
+        """Get clustering result for saving or applying to new data.
 
-        Returns a PredefinedConfig containing all assignment information needed
-        to reproduce this aggregation's clustering and segmentation on new data.
+        Returns a ClusteringResult containing all assignment information that
+        can be saved to disk and/or applied to different datasets.
 
         Returns
         -------
-        PredefinedConfig
-            Config object with cluster_order, cluster_centers (optional),
+        ClusteringResult
+            Object with cluster_order, cluster_centers (optional),
             segment_order (if segmentation), segment_durations (if segmentation).
 
         Examples
         --------
-        >>> result = tsam.aggregate(df, n_periods=8, segments=SegmentConfig(n_segments=6))
+        >>> result = tsam.aggregate(df, n_periods=8)
 
-        >>> # Apply directly to new data
-        >>> result2 = tsam.aggregate(new_data, n_periods=8, predefined=result.predefined)
+        >>> # Apply to new data
+        >>> result2 = result.clustering.apply(new_data)
 
         >>> # Save to file
-        >>> import json
-        >>> with open("predefined.json", "w") as f:
-        ...     json.dump(result.predefined.to_dict(), f)
+        >>> result.clustering.to_json("clustering.json")
 
         >>> # Load and apply
-        >>> with open("predefined.json") as f:
-        ...     predefined = PredefinedConfig.from_dict(json.load(f))
-        >>> result2 = tsam.aggregate(new_data, n_periods=8, predefined=predefined)
+        >>> clustering = ClusteringResult.from_json("clustering.json")
+        >>> result2 = clustering.apply(new_data)
         """
-        from tsam.config import PredefinedConfig
+        from tsam.config import ClusteringResult
 
-        return PredefinedConfig(
+        return ClusteringResult(
             cluster_order=tuple(self.cluster_assignments.tolist()),
             cluster_centers=tuple(self.cluster_center_indices.tolist())
             if self.cluster_center_indices is not None

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -289,24 +289,8 @@ class TestSegmentTransfer:
             segments=SegmentConfig(n_segments=6),
         )
 
-        # Get segment assignments for transfer
-        seg_assignments = result1.segment_assignments
-        seg_durations = result1.segment_durations_tuple
-
-        # Second aggregation with predefined segments and clusters
-        result2 = aggregate(
-            sample_data,
-            n_periods=8,
-            cluster=ClusterConfig(
-                predef_cluster_order=tuple(result1.cluster_assignments),
-                predef_cluster_centers=tuple(result1.cluster_center_indices),
-            ),
-            segments=SegmentConfig(
-                n_segments=6,
-                predef_segment_order=seg_assignments,
-                predef_segment_durations=seg_durations,
-            ),
-        )
+        # Transfer using ClusteringResult.apply()
+        result2 = result1.clustering.apply(sample_data)
 
         # Results should match
         pd.testing.assert_frame_equal(
@@ -429,36 +413,16 @@ class TestClusteringResult:
 class TestSegmentConfigValidation:
     """Tests for SegmentConfig validation."""
 
-    def test_predef_segment_order_requires_durations(self):
-        """Test that predef_segment_order requires predef_segment_durations."""
-        with pytest.raises(ValueError, match="predef_segment_durations"):
-            SegmentConfig(
-                n_segments=6,
-                predef_segment_order=((0, 0, 1, 1, 2, 2),),
-            )
+    def test_n_segments_must_be_positive(self):
+        """Test that n_segments must be positive."""
+        with pytest.raises(ValueError, match="n_segments must be positive"):
+            SegmentConfig(n_segments=0)
 
-    def test_predef_segment_durations_requires_order(self):
-        """Test that predef_segment_durations requires predef_segment_order."""
-        with pytest.raises(ValueError, match="predef_segment_order"):
-            SegmentConfig(
-                n_segments=6,
-                predef_segment_durations=((2, 2, 2),),
-            )
+        with pytest.raises(ValueError, match="n_segments must be positive"):
+            SegmentConfig(n_segments=-1)
 
-    def test_predef_segment_centers_requires_order(self):
-        """Test that predef_segment_centers requires predef_segment_order."""
-        with pytest.raises(ValueError, match="predef_segment_order"):
-            SegmentConfig(
-                n_segments=6,
-                predef_segment_centers=((0, 2, 4),),
-            )
-
-    def test_valid_predef_segment_config(self):
-        """Test that valid predefined segment config doesn't raise."""
-        config = SegmentConfig(
-            n_segments=3,
-            predef_segment_order=((0, 0, 1, 1, 2, 2),),
-            predef_segment_durations=((2, 2, 2),),
-        )
-        assert config.predef_segment_order is not None
-        assert config.predef_segment_durations is not None
+    def test_valid_segment_config(self):
+        """Test that valid segment config doesn't raise."""
+        config = SegmentConfig(n_segments=6)
+        assert config.n_segments == 6
+        assert config.representation == "mean"

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -236,15 +236,15 @@ class TestAssignments:
 class TestSegmentTransfer:
     """Tests for predefined segment transfer."""
 
-    def test_segment_assignments_property(self, sample_data):
-        """Test that segment_assignments property works."""
+    def test_segment_order_in_clustering(self, sample_data):
+        """Test that segment_order is available via clustering property."""
         result = aggregate(
             sample_data,
             n_periods=8,
             segments=SegmentConfig(n_segments=6),
         )
 
-        seg_assignments = result.segment_assignments
+        seg_assignments = result.clustering.segment_order
 
         # Should not be None when segmentation is used
         assert seg_assignments is not None
@@ -252,19 +252,19 @@ class TestSegmentTransfer:
         # Should have one tuple per typical period
         assert len(seg_assignments) == result.n_periods
 
-        # Each inner tuple should sum to timesteps per period
+        # Each inner tuple should have length equal to timesteps per period
         for period_assignments in seg_assignments:
             assert len(period_assignments) == result.n_timesteps_per_period
 
-    def test_segment_durations_tuple_property(self, sample_data):
-        """Test that segment_durations_tuple property works."""
+    def test_segment_durations_in_clustering(self, sample_data):
+        """Test that segment_durations is available via clustering property."""
         result = aggregate(
             sample_data,
             n_periods=8,
             segments=SegmentConfig(n_segments=6),
         )
 
-        seg_durations = result.segment_durations_tuple
+        seg_durations = result.clustering.segment_durations
 
         # Should not be None when segmentation is used
         assert seg_durations is not None
@@ -302,8 +302,8 @@ class TestSegmentTransfer:
         """Test that segment properties return None without segmentation."""
         result = aggregate(sample_data, n_periods=8)
 
-        assert result.segment_assignments is None
-        assert result.segment_durations_tuple is None
+        assert result.clustering.segment_order is None
+        assert result.clustering.segment_durations is None
 
 
 class TestClusteringResult:

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -322,25 +322,26 @@ class TestSegmentTransfer:
         assert result.segment_durations_tuple is None
 
 
-class TestPredef:
-    """Tests for the predefined parameter and PredefinedConfig."""
+class TestClusteringResult:
+    """Tests for ClusteringResult and apply()."""
 
-    def test_predef_property(self, sample_data):
-        """Test that predefined property returns PredefinedConfig."""
-        from tsam import PredefinedConfig
+    def test_clustering_property(self, sample_data):
+        """Test that clustering property returns ClusteringResult."""
+        from tsam import ClusteringResult
 
         result = aggregate(sample_data, n_periods=8)
-        predefined = result.predefined
+        clustering = result.clustering
 
-        assert isinstance(predefined, PredefinedConfig)
-        assert len(predefined.cluster_order) == len(result.cluster_assignments)
+        assert isinstance(clustering, ClusteringResult)
+        assert len(clustering.cluster_order) == len(result.cluster_assignments)
+        assert clustering.n_periods == result.n_periods
 
-    def test_predef_transfer(self, sample_data):
-        """Test transferring with predefined parameter."""
+    def test_clustering_apply(self, sample_data):
+        """Test applying clustering to same data."""
         result1 = aggregate(sample_data, n_periods=8)
 
-        # Transfer using predefined
-        result2 = aggregate(sample_data, n_periods=8, predefined=result1.predefined)
+        # Apply clustering to same data
+        result2 = result1.clustering.apply(sample_data)
 
         # Results should match
         pd.testing.assert_frame_equal(
@@ -348,16 +349,16 @@ class TestPredef:
             result2.typical_periods,
         )
 
-    def test_predef_with_segments(self, sample_data):
-        """Test predefined transfer with segmentation."""
+    def test_clustering_apply_with_segments(self, sample_data):
+        """Test clustering apply with segmentation."""
         result1 = aggregate(
             sample_data,
             n_periods=8,
             segments=SegmentConfig(n_segments=6),
         )
 
-        # Transfer using predefined
-        result2 = aggregate(sample_data, n_periods=8, predefined=result1.predefined)
+        # Apply clustering (includes segment info)
+        result2 = result1.clustering.apply(sample_data)
 
         # Should automatically apply segmentation
         assert result2.n_segments == 6
@@ -366,31 +367,36 @@ class TestPredef:
             result2.typical_periods,
         )
 
-    def test_predef_from_dict(self, sample_data):
-        """Test predefined transfer via dict (for JSON serialization)."""
-        from tsam import PredefinedConfig
+    def test_clustering_from_dict(self, sample_data):
+        """Test clustering transfer via dict (for JSON serialization)."""
+        from tsam import ClusteringResult
 
         result1 = aggregate(sample_data, n_periods=8)
 
         # Convert to dict and back (simulates JSON save/load)
-        predef_dict = result1.predefined.to_dict()
-        predefined = PredefinedConfig.from_dict(predef_dict)
+        clustering_dict = result1.clustering.to_dict()
+        clustering = ClusteringResult.from_dict(clustering_dict)
 
-        result2 = aggregate(sample_data, n_periods=8, predefined=predefined)
+        result2 = clustering.apply(sample_data)
 
         pd.testing.assert_frame_equal(
             result1.typical_periods,
             result2.typical_periods,
         )
 
-    def test_predef_dict_directly(self, sample_data):
-        """Test passing dict directly to predefined parameter."""
+    def test_clustering_json_roundtrip(self, sample_data, tmp_path):
+        """Test saving and loading clustering to/from JSON file."""
+        from tsam import ClusteringResult
+
         result1 = aggregate(sample_data, n_periods=8)
 
-        # Pass dict directly (API accepts both)
-        result2 = aggregate(
-            sample_data, n_periods=8, predefined=result1.predefined.to_dict()
-        )
+        # Save to file
+        json_path = tmp_path / "clustering.json"
+        result1.clustering.to_json(str(json_path))
+
+        # Load and apply
+        clustering = ClusteringResult.from_json(str(json_path))
+        result2 = clustering.apply(sample_data)
 
         pd.testing.assert_frame_equal(
             result1.typical_periods,

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -403,6 +403,28 @@ class TestClusteringResult:
             result2.typical_periods,
         )
 
+    def test_clustering_includes_period_hours(self, sample_data):
+        """Test that clustering includes period_hours."""
+        result = aggregate(sample_data, n_periods=8, period_hours=24)
+        clustering = result.clustering
+
+        assert clustering.period_hours == 24
+        assert clustering.n_periods == 8
+        assert clustering.n_original_periods == len(result.cluster_assignments)
+
+    def test_clustering_period_hours_preserved_in_json(self, sample_data, tmp_path):
+        """Test that period_hours is preserved through JSON serialization."""
+        from tsam import ClusteringResult
+
+        result = aggregate(sample_data, n_periods=8, period_hours=24)
+
+        # Save and load
+        json_path = tmp_path / "clustering.json"
+        result.clustering.to_json(str(json_path))
+        clustering = ClusteringResult.from_json(str(json_path))
+
+        assert clustering.period_hours == 24
+
 
 class TestSegmentConfigValidation:
     """Tests for SegmentConfig validation."""

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -410,6 +410,124 @@ class TestClusteringResult:
         assert clustering.period_hours == 24
 
 
+class TestDeterministicPreservation:
+    """Tests for deterministic clustering preservation through save/load cycles."""
+
+    def test_transfer_fields_preserved_in_json(self, sample_data, tmp_path):
+        """Test that all transfer fields are preserved through JSON roundtrip."""
+        from tsam import ClusteringResult
+
+        result = aggregate(
+            sample_data,
+            n_periods=8,
+            cluster=ClusterConfig(method="kmeans", representation="mean"),
+            segments=SegmentConfig(n_segments=6, representation="medoid"),
+            rescale=False,
+        )
+
+        # Save and load
+        json_path = tmp_path / "clustering.json"
+        result.clustering.to_json(str(json_path))
+        clustering = ClusteringResult.from_json(str(json_path))
+
+        # Verify transfer fields
+        assert clustering.rescale is False
+        assert clustering.representation == "mean"
+        assert clustering.segment_representation == "medoid"
+        assert clustering.period_hours == 24
+        assert len(clustering.cluster_order) == len(result.cluster_assignments)
+        assert clustering.segment_order is not None
+        assert clustering.segment_durations is not None
+
+    def test_representation_method_deterministic(self, sample_data, tmp_path):
+        """Test that representation method produces same results when reapplied."""
+        from tsam import ClusteringResult
+
+        # Test with mean representation
+        result_mean = aggregate(
+            sample_data,
+            n_periods=8,
+            cluster=ClusterConfig(representation="mean"),
+        )
+
+        # Save, load, and reapply
+        json_path = tmp_path / "clustering_mean.json"
+        result_mean.clustering.to_json(str(json_path))
+        clustering = ClusteringResult.from_json(str(json_path))
+        result_reapplied = clustering.apply(sample_data)
+
+        # Results should be identical
+        pd.testing.assert_frame_equal(
+            result_mean.typical_periods,
+            result_reapplied.typical_periods,
+        )
+
+    def test_apply_to_different_data(self, sample_data):
+        """Test applying clustering from subset to full data."""
+        # Cluster on single column
+        wind_only = sample_data[["Wind"]]
+        result_wind = aggregate(wind_only, n_periods=8)
+
+        # Apply to full data
+        result_full = result_wind.clustering.apply(sample_data)
+
+        # Cluster assignments should be identical
+        assert list(result_wind.cluster_assignments) == list(
+            result_full.cluster_assignments
+        )
+
+        # Full result should have all columns
+        assert list(result_full.typical_periods.columns) == list(sample_data.columns)
+
+    def test_segmentation_preserved_through_json(self, sample_data, tmp_path):
+        """Test that segmentation is fully preserved through JSON roundtrip."""
+        from tsam import ClusteringResult
+
+        result1 = aggregate(
+            sample_data,
+            n_periods=8,
+            segments=SegmentConfig(n_segments=6),
+        )
+
+        # Save and load
+        json_path = tmp_path / "clustering_seg.json"
+        result1.clustering.to_json(str(json_path))
+        clustering = ClusteringResult.from_json(str(json_path))
+
+        # Apply to same data
+        result2 = clustering.apply(sample_data)
+
+        # Segmentation structure should match
+        assert result2.n_segments == result1.n_segments
+        assert result2.segment_durations == result1.segment_durations
+
+        # Typical periods should be identical
+        pd.testing.assert_frame_equal(
+            result1.typical_periods,
+            result2.typical_periods,
+        )
+
+    def test_rescale_setting_preserved(self, sample_data, tmp_path):
+        """Test that rescale=False produces different results than rescale=True."""
+        from tsam import ClusteringResult
+
+        # With rescale=False
+        result_no_rescale = aggregate(sample_data, n_periods=8, rescale=False)
+
+        # Save, load, apply
+        json_path = tmp_path / "clustering_no_rescale.json"
+        result_no_rescale.clustering.to_json(str(json_path))
+        clustering = ClusteringResult.from_json(str(json_path))
+        result_reapplied = clustering.apply(sample_data)
+
+        # Should preserve rescale=False behavior
+        assert clustering.rescale is False
+        pd.testing.assert_frame_equal(
+            result_no_rescale.typical_periods,
+            result_reapplied.typical_periods,
+        )
+
+
 class TestSegmentConfigValidation:
     """Tests for SegmentConfig validation."""
 


### PR DESCRIPTION
## Summary

Introduces `ClusteringResult`, a self-contained dataclass for transferring and persisting clustering assignments. This replaces the scattered `predef_*` fields and provides a clean API for saving and reapplying clustering results to new data.

**Key features:**
- Simple serialization with `to_json()` / `from_json()`
- Apply saved clustering to new data with `apply()` - no need to re-specify parameters
- All clustering state bundled in one immutable object
- Deterministic results when applying the same clustering
- New `cluster_assignments()` plot to visualize period-to-cluster mapping

## Example Usage

```python
# Run aggregation
result = tsam.aggregate(df_wind, n_periods=8)

# Save clustering for later use
result.clustering.to_json("clustering.json")

# Load and apply to different data - all parameters come from the file
clustering = ClusteringResult.from_json("clustering.json")
result2 = clustering.apply(df_all)

# Visualize which cluster each original period was assigned to
result.plot.cluster_assignments()
```

## Changes

| File | Change |
|------|--------|
| `config.py` | Add `ClusteringResult` with transfer fields, config references, `to_json()`/`from_json()`, and `apply()` |
| `result.py` | Replace `clustering` cached_property with direct field; derive `n_periods`, `n_segments`, `cluster_assignments` from it |
| `api.py` | Build `ClusteringResult` in `aggregate()` and pass to `AggregationResult` |
| `plot.py` | Add `cluster_assignments()` method to visualize period-to-cluster mapping |
| `__init__.py` | Export `ClusteringResult` instead of `PredefinedConfig` |
| `test_new_api.py` | Update tests to use new API |
| Notebook | Update example to use `ClusteringResult.apply()` |

## ClusteringResult Structure

```python
@dataclass(frozen=True)
class ClusteringResult:
    # Transfer fields (used by apply())
    period_hours: int
    cluster_order: tuple[int, ...]
    cluster_centers: tuple[int, ...] | None = None
    segment_order: tuple[tuple[int, ...], ...] | None = None
    segment_durations: tuple[tuple[int, ...], ...] | None = None
    segment_centers: tuple[tuple[int, ...], ...] | None = None
    rescale: bool = True
    representation: RepresentationMethod = "medoid"
    segment_representation: RepresentationMethod | None = None
    resolution: float | None = None
    
    # Reference fields (for documentation/debugging)
    cluster_config: ClusterConfig | None = None
    segment_config: SegmentConfig | None = None
    extremes_config: ExtremeConfig | None = None
```

## Breaking Changes

- `PredefinedConfig` renamed to `ClusteringResult`
- `result.predefined` property renamed to `result.clustering`
- Removed `predef_*` fields from `ClusterConfig` and `SegmentConfig`
- Removed `predefined` parameter from `aggregate()`