### PR TITLE
Add Segment center preservation

### DIFF
--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -286,6 +286,7 @@ def _build_clustering_result(
     # Compute segment data if segmentation was used
     segment_order: tuple[tuple[int, ...], ...] | None = None
     segment_durations: tuple[tuple[int, ...], ...] | None = None
+    segment_centers: tuple[tuple[int, ...], ...] | None = None
 
     if n_segments is not None and hasattr(agg, "segmentedNormalizedTypicalPeriods"):
         segmented_df = agg.segmentedNormalizedTypicalPeriods
@@ -306,6 +307,18 @@ def _build_clustering_result(
         segment_order = tuple(segment_order_list)
         segment_durations = tuple(segment_durations_list)
 
+        # Extract segment center indices (only available for medoid/maxoid representations)
+        if (
+            hasattr(agg, "segmentCenterIndices")
+            and agg.segmentCenterIndices is not None
+        ):
+            # Check if any period has center indices (None for mean representation)
+            if all(pc is not None for pc in agg.segmentCenterIndices):
+                segment_centers = tuple(
+                    tuple(int(x) for x in period_centers)
+                    for period_centers in agg.segmentCenterIndices
+                )
+
     # Extract representation from configs
     representation = cluster_config.get_representation()
     segment_representation = segment_config.representation if segment_config else None
@@ -316,7 +329,7 @@ def _build_clustering_result(
         cluster_centers=cluster_centers,
         segment_order=segment_order,
         segment_durations=segment_durations,
-        segment_centers=None,  # Not currently captured by segmentation
+        segment_centers=segment_centers,
         rescale=rescale,
         representation=representation,
         segment_representation=segment_representation,

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -1140,6 +1140,7 @@ class TimeSeriesAggregation:
             (
                 self.segmentedNormalizedTypicalPeriods,
                 self.predictedSegmentedNormalizedTypicalPeriods,
+                self.segmentCenterIndices,
             ) = segmentation(
                 self.normalizedTypicalPeriods,
                 self.noSegments,


### PR DESCRIPTION
  Files modified:

  1. src/tsam/utils/segmentation.py:
    - Now returns segment center indices as third return value
    - Added reordering to match temporal order (clusterOrderUnique)
  2. src/tsam/timeseriesaggregation.py:
    - Captures and stores segmentCenterIndices from segmentation
  3. src/tsam/api.py:
    - _build_clustering_result() extracts segment centers (with proper None handling for mean representation)
  4. test/test_new_api.py:
    - Added TestSegmentCenters class with 4 tests: - test_segment_centers_with_medoid - verifies centers are captured
      - test_segment_centers_none_with_mean - verifies None for mean representation
      - test_segment_centers_preserved_in_json - verifies JSON roundtrip - test_segment_centers_deterministic_transfer - verifies deterministic results

  The key fix: The segment center indices from representations() were in cluster label order, but needed to be reordered to match the temporal appearance order (clusterOrderUnique) before being stored. This ensures that when segment centers are used for transfer via ClusteringResult.apply(), the segments map to the correct timestep indices.

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Type of Change

<!-- Please check the relevant options -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

<!-- Please check the relevant options -->

- [ ] My code follows the project's code style (run `ruff check` and `ruff format`)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`pytest test/`)
- [ ] I have updated the documentation if needed
