### PR TITLE
fix: rescaling with segmentation applied rescaling twice

### DIFF
--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -1316,9 +1316,9 @@ class TimeSeriesAggregation:
             index=self.timeSeries.index,
             columns=self.timeSeries.columns,
         )
-        # normalize again if sameMean = True to avoid doubled unnormalization when using _postProcessTimeSeries after
-        # createTypicalPeriods has been called
-        if self.sameMean:
+        # Normalize again if sameMean=True to undo in-place modification from createTypicalPeriods.
+        # But NOT for segmentation - predictedSegmentedNormalizedTypicalPeriods wasn't modified in-place.
+        if self.sameMean and not self.segmentation:
             self.normalizedPredictedData /= self._normalizedMean
         self.predictedData = self._postProcessTimeSeries(
             self.normalizedPredictedData, applyWeighting=False


### PR DESCRIPTION
# Description
Fixed bug in timeseriesaggregation.py:1319-1322 where predictOriginalData() incorrectly denormalized data when using sameMean=True (i.e., normalize_column_means=True) together with segmentation.

  Root cause:
  - Without segmentation: normalizedTypicalPeriods gets modified in-place by _postProcessTimeSeries, so dividing by _normalizedMean in predictOriginalData() was correct
  - With segmentation: predictedSegmentedNormalizedTypicalPeriods is a separate object created before the in-place modification, so it was being incorrectly double-divided

  Fix:
  # Before
  if self.sameMean:
      self.normalizedPredictedData /= self._normalizedMean

  # After
  if self.sameMean and not self.segmentation:
      self.normalizedPredictedData /= self._normalizedMean

## Type of Change

<!-- Please check the relevant options -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

<!-- Please check the relevant options -->

- [ ] My code follows the project's code style (run `ruff check` and `ruff format`)
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`pytest test/`)
- [ ] I have updated the documentation if needed
