### PR TITLE
Fix/n clusters extremes

### DIFF
--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -286,12 +286,15 @@ class AggregationResult:
     def period_index(self) -> list[int]:
         """Get the period (cluster) indices.
 
+        Returns the actual cluster IDs from the cluster_representatives
+        DataFrame, which is the authoritative source.
+
         Returns
         -------
         list[int]
-            List of indices [0, 1, ..., n_clusters-1].
+            Sorted list of cluster indices present in cluster_representatives.
         """
-        return list(range(self.n_clusters))
+        return sorted(self.cluster_representatives.index.get_level_values(0).unique())
 
     @property
     def assignments(self) -> pd.DataFrame:

--- a/src/tsam/result.py
+++ b/src/tsam/result.py
@@ -155,8 +155,13 @@ class AggregationResult:
 
     @cached_property
     def n_clusters(self) -> int:
-        """Number of clusters (typical periods)."""
-        return self.clustering.n_clusters
+        """Number of clusters (typical periods).
+
+        Derived from the cluster_representatives DataFrame index,
+        which is the authoritative source. Note: cluster_weights may
+        have more entries than actual cluster IDs due to tsam quirks.
+        """
+        return self.cluster_representatives.index.get_level_values(0).nunique()
 
     @cached_property
     def n_segments(self) -> int | None:


### PR DESCRIPTION
## Description

Fix `n_clusters` and `period_index` properties in `AggregationResult` to derive values from the `cluster_representatives` DataFrame index rather than from `cluster_weights` or `clustering.n_clusters`.

**Changes:**
- `n_clusters` now uses `cluster_representatives.index.get_level_values(0).nunique()`
- `period_index` now returns actual cluster IDs from the DataFrame instead of assuming consecutive integers

## Motivation and Context

When combining segmentation with extremes using `method='new_cluster'`, tsam creates a mismatch where `cluster_weights` has more entries than actual cluster IDs in `cluster_representatives`. 

For example, requesting 100 clusters with `new_cluster` extremes results in:
- `cluster_weights`: 101 entries (includes phantom extreme cluster)
- `cluster_representatives`: 100 clusters (0-99)

Previously, `n_clusters` returned 101, causing iteration errors. The fix derives the count from the DataFrame index—the authoritative source of what clusters actually exist.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's code style (run `ruff check` and `ruff format`)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`pytest test/`)
- [ ] I have updated the documentation if needed