### PR TITLE
Add rescale_exclude_columns parameter to exclude specific columns from rescaling

### DIFF
--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -53,6 +53,7 @@ def aggregate(
     segments: SegmentConfig | None = None,
     extremes: ExtremeConfig | None = None,
     preserve_column_means: bool = True,
+    rescale_exclude_columns: list[str] | None = None,
     round_decimals: int | None = None,
     numerical_tolerance: float = 1e-13,
 ) -> AggregationResult:
@@ -101,6 +102,11 @@ def aggregate(
         Rescale typical periods so each column's weighted mean matches
         the original data's mean. Ensures total energy/load is preserved
         when weights represent occurrence counts.
+
+    rescale_exclude_columns : list[str], optional
+        Column names to exclude from rescaling when preserve_column_means=True.
+        Useful for binary/indicator columns (0/1 values) that should not be
+        rescaled. If None (default), all columns are rescaled.
 
     round_decimals : int, optional
         Round output values to this many decimal places.
@@ -250,6 +256,7 @@ def aggregate(
         segments=segments,
         extremes=extremes,
         preserve_column_means=preserve_column_means,
+        rescale_exclude_columns=rescale_exclude_columns,
         round_decimals=round_decimals,
         numerical_tolerance=numerical_tolerance,
     )
@@ -293,6 +300,7 @@ def aggregate(
         segment_config=segments,
         extremes_config=extremes,
         preserve_column_means=preserve_column_means,
+        rescale_exclude_columns=rescale_exclude_columns,
         timestep_duration=timestep_duration,
     )
 
@@ -331,6 +339,7 @@ def _build_clustering_result(
     segment_config: SegmentConfig | None,
     extremes_config: ExtremeConfig | None,
     preserve_column_means: bool,
+    rescale_exclude_columns: list[str] | None,
     timestep_duration: float | None,
 ) -> ClusteringResult:
     """Build ClusteringResult from a TimeSeriesAggregation object."""
@@ -387,6 +396,9 @@ def _build_clustering_result(
         segment_durations=segment_durations,
         segment_centers=segment_centers,
         preserve_column_means=preserve_column_means,
+        rescale_exclude_columns=tuple(rescale_exclude_columns)
+        if rescale_exclude_columns
+        else None,
         representation=representation,
         segment_representation=segment_representation,
         timestep_duration=timestep_duration,
@@ -406,6 +418,7 @@ def _build_old_params(
     segments: SegmentConfig | None,
     extremes: ExtremeConfig | None,
     preserve_column_means: bool,
+    rescale_exclude_columns: list[str] | None,
     round_decimals: int | None,
     numerical_tolerance: float,
     *,
@@ -422,6 +435,7 @@ def _build_old_params(
         "noTypicalPeriods": n_clusters,
         "hoursPerPeriod": period_duration,
         "rescaleClusterPeriods": preserve_column_means,
+        "rescaleExcludeColumns": rescale_exclude_columns,
         "numericalTolerance": numerical_tolerance,
     }
 

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -235,6 +235,9 @@ class ClusteringResult:
     preserve_column_means : bool, default True
         Whether to rescale typical periods to match original data means.
 
+    rescale_exclude_columns : tuple[str, ...], optional
+        Column names to exclude from rescaling. Useful for binary columns.
+
     representation : str, default "medoid"
         How to compute typical periods from cluster members.
 
@@ -280,6 +283,7 @@ class ClusteringResult:
     segment_durations: tuple[tuple[int, ...], ...] | None = None
     segment_centers: tuple[tuple[int, ...], ...] | None = None
     preserve_column_means: bool = True
+    rescale_exclude_columns: tuple[str, ...] | None = None
     representation: RepresentationMethod = "medoid"
     segment_representation: RepresentationMethod | None = None
     timestep_duration: float | None = None
@@ -411,6 +415,8 @@ class ClusteringResult:
             result["segment_durations"] = [list(s) for s in self.segment_durations]
         if self.segment_centers is not None:
             result["segment_centers"] = [list(s) for s in self.segment_centers]
+        if self.rescale_exclude_columns is not None:
+            result["rescale_exclude_columns"] = list(self.rescale_exclude_columns)
         if self.segment_representation is not None:
             result["segment_representation"] = self.segment_representation
         if self.timestep_duration is not None:
@@ -447,6 +453,8 @@ class ClusteringResult:
             )
         if "segment_centers" in data:
             kwargs["segment_centers"] = tuple(tuple(s) for s in data["segment_centers"])
+        if "rescale_exclude_columns" in data:
+            kwargs["rescale_exclude_columns"] = tuple(data["rescale_exclude_columns"])
         if "segment_representation" in data:
             kwargs["segment_representation"] = data["segment_representation"]
         if "timestep_duration" in data:
@@ -610,6 +618,9 @@ class ClusteringResult:
             segments=segments,
             extremes=None,
             preserve_column_means=self.preserve_column_means,
+            rescale_exclude_columns=list(self.rescale_exclude_columns)
+            if self.rescale_exclude_columns
+            else None,
             round_decimals=round_decimals,
             numerical_tolerance=numerical_tolerance,
             # Predefined values from this ClusteringResult
@@ -661,6 +672,9 @@ class ClusteringResult:
             segment_config=segments,
             extremes_config=self.extremes_config,
             preserve_column_means=self.preserve_column_means,
+            rescale_exclude_columns=list(self.rescale_exclude_columns)
+            if self.rescale_exclude_columns
+            else None,
             timestep_duration=effective_timestep_duration,
         )
 

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -119,6 +119,7 @@ class TimeSeriesAggregation:
         sortValues=False,
         sameMean=False,
         rescaleClusterPeriods=True,
+        rescaleExcludeColumns=None,
         weightDict=None,
         segmentation=False,
         extremePeriodMethod="None",
@@ -308,6 +309,8 @@ class TimeSeriesAggregation:
         self.sameMean = sameMean
 
         self.rescaleClusterPeriods = rescaleClusterPeriods
+
+        self.rescaleExcludeColumns = rescaleExcludeColumns or []
 
         self.weightDict = weightDict
 
@@ -880,6 +883,9 @@ class TimeSeriesAggregation:
         ).T
         idx_wo_peak = np.delete(typicalPeriods.index, extremeClusterIdx)
         for column in self.timeSeries.columns:
+            # Skip columns excluded from rescaling
+            if column in self.rescaleExcludeColumns:
+                continue
             diff = 1
             sum_raw = self.normalizedPeriodlyProfiles[column].sum().sum()
             sum_peak = np.sum(


### PR DESCRIPTION
## Description

Add `rescale_exclude_columns` parameter to exclude specific columns from rescaling when `preserve_column_means=True`.

**Changes:**
- New parameter `rescale_exclude_columns: list[str] | None` in `aggregate()`
- Excluded columns skip the rescaling loop in `_rescaleClusterPeriods()`
- Setting is stored in `ClusteringResult` and preserved through JSON serialization and `apply()`

## Motivation and Context

When using `preserve_column_means=True` (the default), all columns are rescaled to match their original mean. This causes issues with binary/indicator columns (0/1 values) which get distorted to values like 0.99625, leading to infeasibilities in optimization models.

**Example of the problem:**
```python
# Binary availability column gets distorted
result = tsam.aggregate(data, n_clusters=50, ...)
# Binary column now has values like 0.99625 instead of 1.0
```

**Solution:**
```python
result = tsam.aggregate(
    data,
    n_clusters=50,
    rescale_exclude_columns=['availability_flag', 'on_off_indicator'],
)
# Binary columns preserve exact 0/1 values
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the project's code style (run `ruff check` and `ruff format`)
- [ ] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass (`pytest test/`)
- [ ] I have updated the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now exclude specific columns from rescaling during time series aggregation by specifying them in the new optional `rescale_exclude_columns` parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->