### PR TITLE
Deprecate legacy API with LegacyAPIWarning

### DIFF
--- a/docs/source/newsDoc.rst
+++ b/docs/source/newsDoc.rst
@@ -81,10 +81,21 @@ Improvements
 * Fixed ``predictOriginalData()`` denormalization when using ``sameMean=True`` with segmentation
 * Lazy loading of optional modules (``plot``, ``tuning``) to reduce import time
 
+Deprecations
+============
+
+* **TimeSeriesAggregation class**: The legacy class-based API now emits a ``LegacyAPIWarning`` when instantiated. It will be removed in a future version. Users should migrate to the new ``tsam.aggregate()`` function.
+
+* To suppress the warning during migration::
+
+    import warnings
+    from tsam import LegacyAPIWarning
+    warnings.filterwarnings("ignore", category=LegacyAPIWarning)
+
 Legacy API
 ==========
 
-The class-based API remains available for backward compatibility::
+The class-based API remains available for backward compatibility but is deprecated::
 
     import tsam.timeseriesaggregation as tsam_legacy
 

--- a/docs/source/newsDoc.rst
+++ b/docs/source/newsDoc.rst
@@ -86,7 +86,13 @@ Deprecations
 
 * **TimeSeriesAggregation class**: The legacy class-based API now emits a ``LegacyAPIWarning`` when instantiated. It will be removed in a future version. Users should migrate to the new ``tsam.aggregate()`` function.
 
-* To suppress the warning during migration::
+* **unstackToPeriods function**: Deprecated in favor of ``tsam.unstack_to_periods()``.
+
+* **HyperTunedAggregations class**: The legacy hyperparameter tuning class in ``tsam.hyperparametertuning`` is deprecated. Use ``tsam.tuning.find_optimal_combination()`` or ``tsam.tuning.find_pareto_front()`` instead.
+
+* **getNoPeriodsForDataReduction / getNoSegmentsForDataReduction**: Helper functions deprecated along with ``HyperTunedAggregations``.
+
+* To suppress warnings during migration::
 
     import warnings
     from tsam import LegacyAPIWarning

--- a/src/tsam/__init__.py
+++ b/src/tsam/__init__.py
@@ -54,6 +54,7 @@ def __getattr__(name: str):
 
 
 from tsam.config import ClusterConfig, ClusteringResult, ExtremeConfig, SegmentConfig
+from tsam.exceptions import LegacyAPIWarning
 from tsam.result import AccuracyMetrics, AggregationResult
 
 # Legacy imports for backward compatibility
@@ -67,6 +68,7 @@ __all__ = [
     "ClusterConfig",
     "ClusteringResult",
     "ExtremeConfig",
+    "LegacyAPIWarning",
     "SegmentConfig",
     "TimeSeriesAggregation",
     "aggregate",

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -553,5 +553,7 @@ def unstack_to_periods(
             f"data timestep resolution ({timestep_hours}h)"
         )
 
-    unstacked, _ = unstackToPeriods(data.copy(), timesteps_per_period)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LegacyAPIWarning)
+        unstacked, _ = unstackToPeriods(data.copy(), timesteps_per_period)
     return cast("pd.DataFrame", unstacked)

--- a/src/tsam/api.py
+++ b/src/tsam/api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import cast
 
 import pandas as pd
@@ -15,6 +16,7 @@ from tsam.config import (
     ExtremeConfig,
     SegmentConfig,
 )
+from tsam.exceptions import LegacyAPIWarning
 from tsam.result import AccuracyMetrics, AggregationResult
 from tsam.timeseriesaggregation import TimeSeriesAggregation, unstackToPeriods
 
@@ -254,9 +256,11 @@ def aggregate(
         numerical_tolerance=numerical_tolerance,
     )
 
-    # Run aggregation using old implementation
-    agg = TimeSeriesAggregation(**old_params)
-    cluster_representatives = agg.createTypicalPeriods()
+    # Run aggregation using old implementation (suppress deprecation warning for internal use)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", LegacyAPIWarning)
+        agg = TimeSeriesAggregation(**old_params)
+        cluster_representatives = agg.createTypicalPeriods()
 
     # Rename index levels for consistency with new API terminology
     cluster_representatives = cluster_representatives.rename_axis(

--- a/src/tsam/exceptions.py
+++ b/src/tsam/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exceptions and warnings for tsam."""
+
+
+class LegacyAPIWarning(DeprecationWarning):
+    """Warning for deprecated tsam legacy API usage.
+
+    This warning is raised when using the old class-based API
+    (TimeSeriesAggregation) instead of the new functional API (aggregate).
+
+    Users can suppress this warning during migration with:
+
+        import warnings
+        from tsam.exceptions import LegacyAPIWarning
+        warnings.filterwarnings("ignore", category=LegacyAPIWarning)
+    """
+
+    pass

--- a/src/tsam/hyperparametertuning.py
+++ b/src/tsam/hyperparametertuning.py
@@ -1,8 +1,10 @@
 import copy
+import warnings
 
 import numpy as np
 import tqdm
 
+from tsam.exceptions import LegacyAPIWarning
 from tsam.timeseriesaggregation import TimeSeriesAggregation
 
 
@@ -20,7 +22,15 @@ def getNoPeriodsForDataReduction(noRawTimeSteps, segmentsPerPeriod, dataReductio
     :type dataReduction: float
 
     :returns: **noTypicalPeriods** --  Number of typical periods that can be set.
+
+    .. deprecated::
+        This function is deprecated along with the HyperTunedAggregations class.
     """
+    warnings.warn(
+        "getNoPeriodsForDataReduction is deprecated along with HyperTunedAggregations.",
+        LegacyAPIWarning,
+        stacklevel=2,
+    )
     return int(np.floor(dataReduction * float(noRawTimeSteps) / segmentsPerPeriod))
 
 
@@ -38,7 +48,15 @@ def getNoSegmentsForDataReduction(noRawTimeSteps, typicalPeriods, dataReduction)
     :type dataReduction: float
 
     :returns: **segmentsPerPeriod** --  Number of segments per period that can be set.
+
+    .. deprecated::
+        This function is deprecated along with the HyperTunedAggregations class.
     """
+    warnings.warn(
+        "getNoSegmentsForDataReduction is deprecated along with HyperTunedAggregations.",
+        LegacyAPIWarning,
+        stacklevel=2,
+    )
     return int(np.floor(dataReduction * float(noRawTimeSteps) / typicalPeriods))
 
 
@@ -52,7 +70,17 @@ class HyperTunedAggregations:
 
         :param saveAggregationHistory: Defines if all aggregations that are created during the tuning and iterations shall be saved under self.aggregationHistory.
         :type saveAggregationHistory: boolean
+
+        .. deprecated::
+            Use :func:`tsam.tuning.find_optimal_combination` or
+            :func:`tsam.tuning.find_pareto_front` instead.
         """
+        warnings.warn(
+            "HyperTunedAggregations is deprecated. "
+            "Use tsam.tuning.find_optimal_combination() or tsam.tuning.find_pareto_front() instead.",
+            LegacyAPIWarning,
+            stacklevel=2,
+        )
         self.base_aggregation = base_aggregation
 
         if not isinstance(self.base_aggregation, TimeSeriesAggregation):

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -7,6 +7,7 @@ import pandas as pd
 from sklearn import preprocessing
 from sklearn.metrics import mean_absolute_error, mean_squared_error
 
+from tsam.exceptions import LegacyAPIWarning
 from tsam.periodAggregation import aggregatePeriods
 from tsam.representations import representations
 
@@ -277,6 +278,12 @@ class TimeSeriesAggregation:
             shall be added to the typical periods. optional, default: []
         :type addMeanMax: list
         """
+        warnings.warn(
+            "TimeSeriesAggregation is deprecated and will be removed in a future version. "
+            "Use tsam.aggregate() instead. See the migration guide in the documentation.",
+            LegacyAPIWarning,
+            stacklevel=2,
+        )
         if addMeanMin is None:
             addMeanMin = []
         if addMeanMax is None:

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -39,7 +39,15 @@ def unstackToPeriods(timeSeries, timeStepsPerPeriod):
                 candidate period
               - **timeIndex** (pandas Series index) -- is the modification of the original
                 timeseriesindex in case an integer multiple was created
+
+    .. deprecated::
+        Use :func:`tsam.unstack_to_periods` instead.
     """
+    warnings.warn(
+        "unstackToPeriods is deprecated. Use tsam.unstack_to_periods() instead.",
+        LegacyAPIWarning,
+        stacklevel=2,
+    )
     # init new grouped timeindex
     unstackedTimeSeries = timeSeries.copy()
 
@@ -636,9 +644,11 @@ class TimeSeriesAggregation:
                 self.normalizedTimeSeries[column] * self.weightDict[column]
             )
 
-        self.normalizedPeriodlyProfiles, self.timeIndex = unstackToPeriods(
-            self.normalizedTimeSeries, self.timeStepsPerPeriod
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", LegacyAPIWarning)
+            self.normalizedPeriodlyProfiles, self.timeIndex = unstackToPeriods(
+                self.normalizedTimeSeries, self.timeStepsPerPeriod
+            )
 
         # check if no NaN is in the resulting profiles
         if self.normalizedPeriodlyProfiles.isnull().values.any():


### PR DESCRIPTION
## Summary

Add deprecation warnings to the legacy API to guide users toward the new v3 functional API.

- Add `LegacyAPIWarning` custom warning class for all legacy API deprecations
- Deprecate `TimeSeriesAggregation` class (use `tsam.aggregate()` instead)
- Deprecate `unstackToPeriods` function (use `tsam.unstack_to_periods()` instead)
- Deprecate `HyperTunedAggregations` class and helper functions (use `tsam.tuning` module instead)
- Suppress warnings for internal usage in the new API
- Update release notes with deprecation documentation

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] My code follows the project's code style (run `ruff check` and `ruff format`)
- [x] All new and existing tests pass (`pytest test/`)
- [x] I have updated the documentation if needed

## Migration

Users of the legacy API will now see deprecation warnings:

```python
# Suppress warnings during gradual migration:
import warnings
from tsam import LegacyAPIWarning
warnings.filterwarnings("ignore", category=LegacyAPIWarning)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)