### PR TITLE
perf: Vectorize predictOriginalData() for 35x workflow speedup

### DIFF
--- a/docs/source/newsDoc.rst
+++ b/docs/source/newsDoc.rst
@@ -84,13 +84,12 @@ Improvements
 Performance
 ===========
 
-* **290x faster reconstruction**: Vectorized ``predictOriginalData()`` by replacing a per-period loop with batch pandas operations. Full workflow speedup of ~40x for yearly data.
+* **35x faster workflow**: Vectorized ``predictOriginalData()`` by replacing a per-period loop with batch pandas operations.
 
   ==================================  ==========  ==========  =========
-  Benchmark (8760 hours, 5 columns)   Before      After       Speedup
+  Benchmark (8760 hours, 4 columns)   Before      After       Speedup
   ==================================  ==========  ==========  =========
-  ``predictOriginalData()``           650 ms      2.2 ms      **290x**
-  Full workflow with accuracy         ~2.4 s      ~0.06 s     **~40x**
+  Full workflow with accuracy         1223 ms     35 ms       **35x**
   ==================================  ==========  ==========  =========
 
 Deprecations

--- a/docs/source/newsDoc.rst
+++ b/docs/source/newsDoc.rst
@@ -81,6 +81,18 @@ Improvements
 * Fixed ``predictOriginalData()`` denormalization when using ``sameMean=True`` with segmentation
 * Lazy loading of optional modules (``plot``, ``tuning``) to reduce import time
 
+Performance
+===========
+
+* **290x faster reconstruction**: Vectorized ``predictOriginalData()`` by replacing a per-period loop with batch pandas operations. Full workflow speedup of ~40x for yearly data.
+
+  ==================================  ==========  ==========  =========
+  Benchmark (8760 hours, 5 columns)   Before      After       Speedup
+  ==================================  ==========  ==========  =========
+  ``predictOriginalData()``           650 ms      2.2 ms      **290x**
+  Full workflow with accuracy         ~2.4 s      ~0.06 s     **~40x**
+  ==================================  ==========  ==========  =========
+
 Deprecations
 ============
 


### PR DESCRIPTION
## Summary

Optimize `predictOriginalData()` by replacing a slow loop with vectorized pandas operations.

**Problem:** The method had a loop calling `.unstack()` once per period (365 times for yearly data):
```python
for label in self._clusterOrder:  # 365 iterations!
    new_data.append(
        self.normalizedTypicalPeriods.loc[label, :].unstack().values
    )
```

**Solution:** Unstack once, then use vectorized `.loc[]` indexing:
```python
typical_unstacked = typical.unstack()
reconstructed = typical_unstacked.loc[list(self._clusterOrder)].values
```

## Benchmark Results

Measured by running full workflow on both git states (before/after this commit):

| Benchmark | Before | After | Speedup |
|-----------|--------|-------|---------|
| Full workflow | 1223 ms | 35 ms | **35x** |

Data: `testdata.csv` (8760 hours, 4 columns: GHI, T, Wind, Load)

## Benchmark Code

```python
import pandas as pd
import numpy as np
import warnings
import time

warnings.filterwarnings('ignore')

raw = pd.read_csv(
    "docs/source/examples_notebooks/testdata.csv",
    index_col=0,
    parse_dates=True
)
print(f"Dataset: {raw.shape}")

import tsam

# Warm up
result = tsam.aggregate(raw, n_clusters=8, period_duration=24)
_ = result.accuracy
_ = result.reconstructed

# Benchmark
times = []
for _ in range(5):
    start = time.perf_counter()
    result = tsam.aggregate(raw, n_clusters=8, period_duration=24)
    _ = result.accuracy
    _ = result.reconstructed
    times.append(time.perf_counter() - start)

print(f'Full workflow: {np.mean(times)*1000:.1f} ms')
```

**Results:**
```
# Before optimization (commit d1e97e8):
Full workflow: 1223.3 ms

# After optimization:
Full workflow: 35.1 ms

Speedup: 35x
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the project's code style (run `ruff check` and `ruff format`)
- [x] All new and existing tests pass (`pytest test/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)