### PR TITLE
perf: Vectorize duration representation for 5x speedup

### DIFF
--- a/src/tsam/utils/durationRepresentation.py
+++ b/src/tsam/utils/durationRepresentation.py
@@ -42,49 +42,52 @@ def durationRepresentation(
     # (periodWise = True) or the distribution of the total time series is preserved only. In the latter case, the
     # inner-cluster variance is smaller and the variance across the typical periods' mean values is higher
     if distributionPeriodWise:
-        clusterCenters = []
+        # Vectorized implementation using numpy 3D arrays instead of pandas MultiIndex
+        n_periods = candidates.shape[0]
+        n_attrs = num_attributes
 
+        # Reshape to 3D: (periods, attributes, timesteps)
+        candidates_3d = candidates.reshape(n_periods, n_attrs, timeStepsPerPeriod)
+
+        clusterCenters = []
         for clusterNum in np.unique(clusterOrder):
             indice = np.where(clusterOrder == clusterNum)[0]
-            noCandidates = len(indice)
+            n_cands = len(indice)
 
             # Skip empty clusters
-            if len(indice) == 0:
+            if n_cands == 0:
                 continue
 
-            # This list will hold the representative values for each attribute
-            clusterCenter_parts = []
+            # Get all candidates for this cluster: (n_cands, n_attrs, timesteps)
+            cluster_data = candidates_3d[indice]
 
-            for a in candidates_df.columns.levels[0]:
-                candidateValues_np = candidates_df.loc[indice, a].values
+            # Process all attributes at once using vectorized operations
+            # Reshape to (n_attrs, n_cands * timesteps) for sorting
+            flat_per_attr = cluster_data.transpose(1, 0, 2).reshape(n_attrs, -1)
 
-                # flatten the 2D array (candidates, timesteps) into a 1D array and sort it.
-                sorted_flat_values = np.sort(candidateValues_np.flatten())
+            # Sort each attribute's values
+            sorted_flat = np.sort(flat_per_attr, axis=1)
 
-                # reshape the sorted values and calculate the mean for each representative time step.
-                representationValues_np = sorted_flat_values.reshape(
-                    timeStepsPerPeriod, noCandidates
-                ).mean(axis=1)
+            # Reshape and mean: (n_attrs, timesteps, n_cands) -> mean -> (n_attrs, timesteps)
+            sorted_reshaped = sorted_flat.reshape(n_attrs, timeStepsPerPeriod, n_cands)
+            repr_values = sorted_reshaped.mean(axis=2)
 
-                # respect max and min of the attributes
-                if representMinMax:
-                    representationValues_np[0] = sorted_flat_values[0]
-                    representationValues_np[-1] = sorted_flat_values[-1]
+            # Respect max and min of the attributes
+            if representMinMax:
+                repr_values[:, 0] = sorted_flat[:, 0]
+                repr_values[:, -1] = sorted_flat[:, -1]
 
-                # get the order of the representation values such that euclidean distance
-                # to the candidates' mean profile is minimized.
-                mean_profile_order = np.argsort(candidateValues_np.mean(axis=0))
+            # Get mean profile order for each attribute
+            mean_profiles = cluster_data.mean(axis=0)  # (n_attrs, timesteps)
+            orders = np.argsort(mean_profiles, axis=1)  # (n_attrs, timesteps)
 
-                # Create an empty array to place the results in the correct order
-                final_representation_for_attr = np.empty_like(representationValues_np)
-                final_representation_for_attr[mean_profile_order] = (
-                    representationValues_np
-                )
+            # Reorder repr_values according to orders
+            final_repr = np.empty_like(repr_values)
+            for a in range(n_attrs):
+                final_repr[a, orders[a]] = repr_values[a]
 
-                # add to cluster center
-                clusterCenter_parts.append(final_representation_for_attr)
-
-            clusterCenters.append(np.concatenate(clusterCenter_parts))
+            # Flatten to (n_attrs * timesteps,)
+            clusterCenters.append(final_repr.flatten())
 
     else:
         clusterCentersList = []


### PR DESCRIPTION
## Summary

- Replaces pandas MultiIndex indexing loop with numpy 3D array operations
- Eliminates repeated `candidates_df.loc[indice, a]` calls (N attributes × M clusters)
- **5x speedup** on distribution representation workflow

## Benchmark

```python
import pandas as pd
import numpy as np
import warnings
import time

warnings.filterwarnings('ignore')

df = pd.read_parquet('clustering_data.parquet')  # 8760 x 188

from tsam.timeseriesaggregation import TimeSeriesAggregation

times = []
for _ in range(5):
    start = time.perf_counter()
    agg = TimeSeriesAggregation(
        df,
        noTypicalPeriods=8,
        hoursPerPeriod=24,
        representationMethod='distributionAndMinMaxRepresentation',
        clusterMethod='hierarchical',
    )
    typical = agg.createTypicalPeriods()
    times.append(time.perf_counter() - start)

print(f'Average: {np.mean(times)*1000:.0f} ms')
```

| Benchmark (8760 hours, 188 columns) | Before | After | Speedup |
|-------------------------------------|--------|-------|---------|
| Distribution representation workflow | 874 ms | 183 ms | **4.8x** |

## Changes

**Before** - nested loop with pandas MultiIndex indexing:
```python
for clusterNum in np.unique(clusterOrder):
    indice = np.where(clusterOrder == clusterNum)[0]
    for a in candidates_df.columns.levels[0]:
        candidateValues_np = candidates_df.loc[indice, a].values
        # process each attribute separately...
```

**After** - vectorized numpy operations:
```python
# Reshape to 3D: (periods, attributes, timesteps)
candidates_3d = candidates.reshape(n_periods, n_attrs, timeStepsPerPeriod)

for clusterNum in np.unique(clusterOrder):
    indice = np.where(clusterOrder == clusterNum)[0]
    cluster_data = candidates_3d[indice]
    
    # Process all attributes at once
    flat_per_attr = cluster_data.transpose(1, 0, 2).reshape(n_attrs, -1)
    sorted_flat = np.sort(flat_per_attr, axis=1)
    # ...vectorized operations on all attributes simultaneously
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)