### PR TITLE
Rename timestep_duration to temporal_resolution

### DIFF
--- a/docs/source/gettingStartedDoc.rst
+++ b/docs/source/gettingStartedDoc.rst
@@ -151,7 +151,7 @@ Key concepts used in the tsam API:
      - Number of segments per period. If not specified, equals timesteps per period (no segmentation).
    * - ``period_duration``
      - Length of each period. Accepts int/float (hours) or pandas Timedelta strings (e.g., ``24``, ``'24h'``, ``'1d'``).
-   * - ``timestep_duration``
+   * - ``temporal_resolution``
      - Time resolution of input data. Accepts float (hours) or pandas Timedelta strings (e.g., ``1.0``, ``'1h'``, ``'15min'``). If not provided, inferred from the datetime index.
    * - ``cluster_assignments``
      - Array mapping each original period to its cluster index (0 to n_clusters-1).

--- a/docs/source/newsDoc.rst
+++ b/docs/source/newsDoc.rst
@@ -21,7 +21,7 @@ Breaking Changes
   ==================================  ======================================================
   ``noTypicalPeriods``                ``n_clusters``
   ``hoursPerPeriod``                  ``period_duration``
-  ``resolution``                      ``timestep_duration``
+  ``resolution``                      ``temporal_resolution``
   ``clusterMethod``                   ``cluster=ClusterConfig(method=...)``
   ``representationMethod``            ``cluster=ClusterConfig(representation=...)``
   ``segmentation`` + ``noSegments``   ``segments=SegmentConfig(n_segments=...)``

--- a/src/tsam/config.py
+++ b/src/tsam/config.py
@@ -245,7 +245,7 @@ class ClusteringResult:
     segment_representation : str, optional
         How to compute segment values. Only used if segmentation is present.
 
-    timestep_duration : float, optional
+    temporal_resolution : float, optional
         Time resolution of input data in hours. If not provided, inferred.
 
     Reference Fields (for documentation, not used by apply())
@@ -287,7 +287,7 @@ class ClusteringResult:
     rescale_exclude_columns: tuple[str, ...] | None = None
     representation: RepresentationMethod = "medoid"
     segment_representation: RepresentationMethod | None = None
-    timestep_duration: float | None = None
+    temporal_resolution: float | None = None
 
     # === Reference fields (for documentation, not used by apply()) ===
     cluster_config: ClusterConfig | None = None
@@ -420,8 +420,8 @@ class ClusteringResult:
             result["rescale_exclude_columns"] = list(self.rescale_exclude_columns)
         if self.segment_representation is not None:
             result["segment_representation"] = self.segment_representation
-        if self.timestep_duration is not None:
-            result["timestep_duration"] = self.timestep_duration
+        if self.temporal_resolution is not None:
+            result["temporal_resolution"] = self.temporal_resolution
         # Reference fields (optional, for documentation)
         if self.cluster_config is not None:
             result["cluster_config"] = self.cluster_config.to_dict()
@@ -458,8 +458,8 @@ class ClusteringResult:
             kwargs["rescale_exclude_columns"] = tuple(data["rescale_exclude_columns"])
         if "segment_representation" in data:
             kwargs["segment_representation"] = data["segment_representation"]
-        if "timestep_duration" in data:
-            kwargs["timestep_duration"] = data["timestep_duration"]
+        if "temporal_resolution" in data:
+            kwargs["temporal_resolution"] = data["temporal_resolution"]
         # Reference fields
         if "cluster_config" in data:
             kwargs["cluster_config"] = ClusterConfig.from_dict(data["cluster_config"])
@@ -514,7 +514,7 @@ class ClusteringResult:
         self,
         data: pd.DataFrame,
         *,
-        timestep_duration: float | None = None,
+        temporal_resolution: float | None = None,
         round_decimals: int | None = None,
         numerical_tolerance: float = 1e-13,
     ) -> AggregationResult:
@@ -529,9 +529,9 @@ class ClusteringResult:
             Input time series data with a datetime index.
             Must have the same number of periods as the original data.
 
-        timestep_duration : float, optional
+        temporal_resolution : float, optional
             Time resolution of input data in hours.
-            If not provided, uses stored timestep_duration or infers from data index.
+            If not provided, uses stored temporal_resolution or infers from data index.
 
         round_decimals : int, optional
             Round output values to this many decimal places.
@@ -560,22 +560,22 @@ class ClusteringResult:
         from tsam.result import AccuracyMetrics, AggregationResult
         from tsam.timeseriesaggregation import TimeSeriesAggregation
 
-        # Use stored timestep_duration if not provided
-        effective_timestep_duration = (
-            timestep_duration
-            if timestep_duration is not None
-            else self.timestep_duration
+        # Use stored temporal_resolution if not provided
+        effective_temporal_resolution = (
+            temporal_resolution
+            if temporal_resolution is not None
+            else self.temporal_resolution
         )
 
         # Validate n_timesteps_per_period matches data
         # Infer timestep duration from data if not provided
-        if effective_timestep_duration is None:
+        if effective_temporal_resolution is None:
             if isinstance(data.index, pd.DatetimeIndex) and len(data.index) > 1:
                 inferred = (data.index[1] - data.index[0]).total_seconds() / 3600
             else:
                 inferred = 1.0  # Default to hourly
         else:
-            inferred = effective_timestep_duration
+            inferred = effective_temporal_resolution
 
         inferred_timesteps = int(self.period_duration / inferred)
         if inferred_timesteps != self.n_timesteps_per_period:
@@ -615,7 +615,7 @@ class ClusteringResult:
             data=data,
             n_clusters=self.n_clusters,
             period_duration=self.period_duration,
-            timestep_duration=effective_timestep_duration,
+            temporal_resolution=effective_temporal_resolution,
             cluster=cluster,
             segments=segments,
             extremes=None,
@@ -679,7 +679,7 @@ class ClusteringResult:
             rescale_exclude_columns=list(self.rescale_exclude_columns)
             if self.rescale_exclude_columns
             else None,
-            timestep_duration=effective_timestep_duration,
+            temporal_resolution=effective_temporal_resolution,
         )
 
         # Build result object

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -659,14 +659,14 @@ class TestDurationParsing:
             result_float.cluster_representatives,
         )
 
-    def test_timestep_duration_string(self, sample_data):
-        """Test that timestep_duration accepts pandas Timedelta strings."""
+    def test_temporal_resolution_string(self, sample_data):
+        """Test that temporal_resolution accepts pandas Timedelta strings."""
         # Should be equivalent: 1.0 hours and '1h'
         result_float = aggregate(
-            sample_data, n_clusters=8, period_duration=24, timestep_duration=1.0
+            sample_data, n_clusters=8, period_duration=24, temporal_resolution=1.0
         )
         result_str = aggregate(
-            sample_data, n_clusters=8, period_duration="24h", timestep_duration="1h"
+            sample_data, n_clusters=8, period_duration="24h", temporal_resolution="1h"
         )
 
         pd.testing.assert_frame_equal(


### PR DESCRIPTION
## Description

Completes the rename of `timestep_duration` to `temporal_resolution` in the documentation.

## Motivation and Context

To be consistent with the papers

## Checklist

- [x] My code follows the project's code style (run `ruff check` and `ruff format`)
- [x] All new and existing tests pass (`pytest test/`)
- [x] I have updated the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed public parameter `timestep_duration` to `temporal_resolution` across the API for improved terminology consistency.

* **Documentation**
  * Updated glossary and breaking changes documentation to reflect the parameter rename and provide migration guidance.

* **Tests**
  * Updated test suite to use the renamed parameter in API calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->