### PR TITLE
Fix/tests

### DIFF
--- a/src/tsam/tuning.py
+++ b/src/tsam/tuning.py
@@ -94,7 +94,7 @@ def _test_single_config_file(
             round_decimals=opts["round_decimals"],
             numerical_tolerance=opts["numerical_tolerance"],
         )
-        rmse = float(result.accuracy.rmse.mean())
+        rmse = float(np.sqrt((result.accuracy.rmse**2).mean()))
         return (n_clusters, n_segments, rmse, result)
     except Exception as e:
         logger.warning(
@@ -234,7 +234,7 @@ def _test_configs(
                     round_decimals=aggregate_opts["round_decimals"],
                     numerical_tolerance=aggregate_opts["numerical_tolerance"],
                 )
-                rmse = float(result.accuracy.rmse.mean())
+                rmse = float(np.sqrt((result.accuracy.rmse**2).mean()))
                 results.append((n_per, n_seg, rmse, result))
             except Exception as e:
                 logger.debug("Config (%d, %d) failed: %s", n_per, n_seg, e)

--- a/test/test_api_equivalence.py
+++ b/test/test_api_equivalence.py
@@ -442,8 +442,8 @@ class TestTuningEquivalence:
         # Last RMSE should be 0 (full resolution)
         assert new_rmse_history[-1] < 1e-10
 
-    def test_save_all_results(self, small_data):
-        """Test that save_all_results stores all AggregationResults."""
+    def test_find_optimal_combination_save_all_results(self, small_data):
+        """Test that find_optimal_combination with save_all_results stores all AggregationResults."""
         result = find_optimal_combination(
             small_data,
             data_reduction=0.1,

--- a/test/test_api_equivalence.py
+++ b/test/test_api_equivalence.py
@@ -53,10 +53,10 @@ class TestAggregateEquivalence:
             cluster=ClusterConfig(method="hierarchical"),
         )
 
-        # Compare typical periods
+        # Compare typical periods (check_names=False: old uses 'TimeStep', new uses 'timestep')
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -98,8 +98,9 @@ class TestAggregateEquivalence:
 
         # With same seed, results should be identical
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
+            check_names=False,
         )
 
         old_accuracy = old_agg.accuracyIndicators()
@@ -130,8 +131,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -158,8 +159,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -186,8 +187,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -212,8 +213,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -240,8 +241,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -265,8 +266,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -292,8 +293,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -320,8 +321,8 @@ class TestAggregateEquivalence:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -495,8 +496,8 @@ class TestSubhourlyResolution:
         )
 
         pd.testing.assert_frame_equal(
-            old_result.reset_index(drop=True),
-            new_result.cluster_representatives.reset_index(drop=True),
+            old_result,
+            new_result.cluster_representatives,
             check_names=False,
         )
 
@@ -551,8 +552,8 @@ class TestReconstructionEquivalence:
         new_reconstructed = new_result.reconstructed
 
         pd.testing.assert_frame_equal(
-            old_reconstructed.reset_index(drop=True),
-            new_reconstructed.reset_index(drop=True),
+            old_reconstructed,
+            new_reconstructed,
             check_names=False,
         )
 

--- a/test/test_api_equivalence.py
+++ b/test/test_api_equivalence.py
@@ -97,6 +97,11 @@ class TestAggregateEquivalence:
         )
 
         # With same seed, results should be identical
+        pd.testing.assert_frame_equal(
+            old_result.reset_index(drop=True),
+            new_result.cluster_representatives.reset_index(drop=True),
+        )
+
         old_accuracy = old_agg.accuracyIndicators()
         np.testing.assert_allclose(
             old_accuracy["RMSE"].values,

--- a/test/test_api_equivalence.py
+++ b/test/test_api_equivalence.py
@@ -435,6 +435,9 @@ class TestTuningEquivalence:
         # Get RMSE history from summary
         new_rmse_history = new_results.summary["rmse"].tolist()
 
+        # RMSE histories should match between old and new API
+        np.testing.assert_allclose(new_rmse_history, old_rmse_history, rtol=1e-10)
+
         # RMSE should be monotonically decreasing (or equal)
         for i in range(1, len(new_rmse_history)):
             assert new_rmse_history[i] <= new_rmse_history[i - 1] + 1e-10

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -288,8 +288,8 @@ class TestSegmentTransfer:
 class TestClusteringResult:
     """Tests for ClusteringResult and apply()."""
 
-    def test_clustering_property(self, sample_data):
-        """Test that clustering property returns ClusteringResult."""
+    def test_clustering_property_and_apply(self, sample_data):
+        """Test that clustering property returns ClusteringResult and can be applied."""
         from tsam import ClusteringResult
 
         result = aggregate(sample_data, n_clusters=8)
@@ -299,16 +299,10 @@ class TestClusteringResult:
         assert len(clustering.cluster_assignments) == len(result.cluster_assignments)
         assert clustering.n_clusters == result.n_clusters
 
-    def test_clustering_apply(self, sample_data):
-        """Test applying clustering to same data."""
-        result1 = aggregate(sample_data, n_clusters=8)
-
         # Apply clustering to same data
-        result2 = result1.clustering.apply(sample_data)
-
-        # Results should match
+        result2 = clustering.apply(sample_data)
         pd.testing.assert_frame_equal(
-            result1.cluster_representatives,
+            result.cluster_representatives,
             result2.cluster_representatives,
         )
 

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -616,6 +616,24 @@ class TestDurationParsing:
             result_float.cluster_representatives,
         )
 
+    def test_non_hour_period_duration(self):
+        """Test period_duration that doesn't align to whole hours (e.g. 45 minutes)."""
+        import numpy as np
+
+        np.random.seed(42)
+        # Create 15-min data for 3 days (288 timesteps)
+        dates = pd.date_range("2020-01-01", periods=3 * 96, freq="15min")
+        data = pd.DataFrame(
+            {"x": np.sin(np.linspace(0, 6 * np.pi, len(dates)))},
+            index=dates,
+        )
+
+        # 45 minutes = 3 timesteps at 15-min resolution
+        result = aggregate(data, n_clusters=2, period_duration="45min")
+
+        assert result.n_timesteps_per_period == 3
+        assert result.cluster_representatives is not None
+
     def test_temporal_resolution_string(self, sample_data):
         """Test that temporal_resolution accepts pandas Timedelta strings."""
         # Should be equivalent: 1.0 hours and '1h'

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -236,48 +236,27 @@ class TestAssignments:
 class TestSegmentTransfer:
     """Tests for predefined segment transfer."""
 
-    def test_segment_assignments_in_clustering(self, sample_data):
-        """Test that segment_assignments is available via clustering property."""
+    def test_segment_assignments_and_durations_in_clustering(self, sample_data):
+        """Test that segment_assignments and segment_durations are available via clustering."""
         result = aggregate(
             sample_data,
             n_clusters=8,
             segments=SegmentConfig(n_segments=6),
         )
 
+        # Segment assignments
         seg_assignments = result.clustering.segment_assignments
-
-        # Should not be None when segmentation is used
         assert seg_assignments is not None
-
-        # Should have one tuple per typical period
         assert len(seg_assignments) == 8
-
-        # Each inner tuple should have length equal to timesteps per period
         for period_assignments in seg_assignments:
             assert len(period_assignments) == result.n_timesteps_per_period
 
-    def test_segment_durations_in_clustering(self, sample_data):
-        """Test that segment_durations is available via clustering property."""
-        result = aggregate(
-            sample_data,
-            n_clusters=8,
-            segments=SegmentConfig(n_segments=6),
-        )
-
+        # Segment durations
         seg_durations = result.clustering.segment_durations
-
-        # Should not be None when segmentation is used
         assert seg_durations is not None
-
-        # Should have one tuple per typical period
-        assert len(seg_durations) == result.n_clusters
-
-        # Each inner tuple should have n_segments elements
+        assert len(seg_durations) == 8
         for period_durations in seg_durations:
             assert len(period_durations) == 6
-
-        # Durations should sum to timesteps per period
-        for period_durations in seg_durations:
             assert sum(period_durations) == result.n_timesteps_per_period
 
     def test_segment_transfer(self, sample_data):

--- a/test/test_new_api.py
+++ b/test/test_new_api.py
@@ -250,7 +250,7 @@ class TestSegmentTransfer:
         assert seg_assignments is not None
 
         # Should have one tuple per typical period
-        assert len(seg_assignments) == result.n_clusters
+        assert len(seg_assignments) == 8
 
         # Each inner tuple should have length equal to timesteps per period
         for period_assignments in seg_assignments:

--- a/test/test_reconstruct_samemean_segmentation.py
+++ b/test/test_reconstruct_samemean_segmentation.py
@@ -15,6 +15,7 @@ import pytest
 
 import tsam
 from tsam import ClusterConfig, SegmentConfig
+from tsam.result import AggregationResult
 
 
 @pytest.fixture
@@ -35,7 +36,9 @@ def test_data():
 class TestReconstructSameMeanSegmentation:
     """Test reconstruction with normalize_column_means + segmentation."""
 
-    def _check_reconstruction_bounds(self, result, max_ratio=1.5):
+    def _check_reconstruction_bounds(
+        self, result: AggregationResult, max_ratio: float = 1.5
+    ):
         """Check that reconstructed values are within reasonable bounds."""
         original = result._aggregation.timeSeries
         reconstructed = result.reconstructed


### PR DESCRIPTION
Fix tests as addressed in https://github.com/FZJ-IEK3-VSA/tsam/pull/127

| # | Issue | Fix |
|---|-------|-----|
| 1 | Missing comparison in `test_kmeans` | Added `assert_frame_equal` for typical periods |
| 2/3 | `reset_index(drop=True)` hiding index issues | Removed all `reset_index(drop=True)`, using `check_names=False` instead |
| 4 | `old_history` unused in `test_find_pareto_front` | Added comparison and fixed incosistencies between api's |
| 5 | `test_save_all_results` misleading name | Renamed to `test_find_optimal_combination_save_all_results` |
| 6 | Should test against literal `n_cluster=8` | Changed assertion to use `8` instead of `result.n_clusters` |
| 7 | Two tests share same config | Merged into `test_segment_assignments_and_durations_in_clustering` |
| 8 | `test_clustering_apply` same config as `test_clustering_property` | Merged into `test_clustering_property_and_apply` |
| 9 | `test_clustering_json_roundtrip` same config | Merged into `test_clustering_from_dict_and_json` |
| 10 | `test_clustering_period_duration_preserved_in_json` same config | Merged into `test_clustering_includes_period_duration` |
| 11 | Missing non-hour period duration test | Added `test_non_hour_period_duration` with 45-min periods |
| 12 | Missing type hints | Added `AggregationResult` and `float` type hints |

## Bug Fixes:
* `find_pareto_front` used rmse.mean() instead of sqrt(mean(rmse²)).

## Topics to discuss:
* New api has inde name `timestep`, not `TimeStep`. The tests skips comparing the index names.
* `test_find_pareto_front` has different results than the old api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RMSE calculation methodology to provide more accurate metric reporting.

* **Improvements**
  * Enhanced validation of clustering properties including segment assignments and durations.
  * Verified support for non-hour period durations.
  * Confirmed data persistence across JSON and dictionary serialization.
  * Strengthened API compatibility testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->