### PR TITLE
Make pyomo, highspy, and networkx optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,16 +35,29 @@ dependencies = [
   "scikit-learn>=1.3.0,<=1.8.0",
   "pandas>=2.2.0,<=3.0.1",
   "numpy>=1.22.4,<=2.4.2",
-  "pyomo>=6.4.8,<=6.10.0",
-  "networkx>=2.5,<=3.6.1",
   "tqdm>=4.21.0,<=4.67.3",
-  "highspy>=1.7.2,<=1.13.1",
 ]
 
 requires-python = ">=3.10,<3.15"
 
 [project.optional-dependencies]
+kmedoids = ["pyomo>=6.4.8,<=6.10.0", "highspy>=1.7.2,<=1.13.1"]
+contiguity = [
+  "pyomo>=6.4.8,<=6.10.0",
+  "highspy>=1.7.2,<=1.13.1",
+  "networkx>=2.5,<=3.6.1",
+]
+full = [
+  "pyomo>=6.4.8,<=6.10.0",
+  "highspy>=1.7.2,<=1.13.1",
+  "networkx>=2.5,<=3.6.1",
+]
+plot = ["plotly>=5.0.0"]
+notebooks = ["notebook>=7.5.0", "plotly>=5.0.0"]
 develop = [
+  "pyomo>=6.4.8,<=6.10.0",
+  "highspy>=1.7.2,<=1.13.1",
+  "networkx>=2.5,<=3.6.1",
   "pytest",
   "pytest-cov",
   "pytest-xdist",
@@ -63,8 +76,6 @@ develop = [
   "plotly>=5.0.0",
   "notebook>=7.5.0",
 ]
-plot = ["plotly>=5.0.0"]
-notebooks = ["notebook>=7.5.0", "plotly>=5.0.0"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/tsam/utils/k_medoids_contiguity.py
+++ b/src/tsam/utils/k_medoids_contiguity.py
@@ -6,15 +6,36 @@ import numpy as np
 np.float_ = np.float64  # type: ignore[attr-defined]
 np.complex_ = np.complex128  # type: ignore[attr-defined]
 
-import networkx as nx
-import pyomo.environ as pyomo
-
 from tsam.utils.k_medoids_exact import (
     _setup_k_medoids,
     _solve_given_pyomo_model,
 )
 
-# class KMedoids_contiguity(KMedoids):
+
+def _import_networkx():
+    """Lazy import networkx with helpful error message."""
+    try:
+        import networkx as nx
+
+        return nx
+    except ImportError:
+        raise ImportError(
+            "The contiguity-constrained clustering method requires networkx. "
+            "Install it with: pip install tsam[contiguity]"
+        ) from None
+
+
+def _import_pyomo():
+    """Lazy import pyomo with helpful error message."""
+    try:
+        import pyomo.environ as pyomo
+
+        return pyomo
+    except ImportError:
+        raise ImportError(
+            "The contiguity-constrained clustering method requires pyomo. "
+            "Install it with: pip install tsam[contiguity]"
+        ) from None
 
 
 def k_medoids_contiguity(
@@ -24,6 +45,9 @@ def k_medoids_contiguity(
 
     The algorithm is based on: Oehrlein and Hauner (2017): A cutting-plane method for adjacency-constrained spatial aggregation
     """
+    nx = _import_networkx()
+    pyomo = _import_pyomo()
+
     # First transform the network to a networkx instance which is required for cut generation
     G = _contiguity_to_graph(adjacency, distances=distances)
 
@@ -122,6 +146,7 @@ def _contiguity_to_graph(adjacency, distances=None):
     Returns:
         nx.Graph: Graph with every index as node name.
     """
+    nx = _import_networkx()
     rows, cols = np.where(adjacency == 1)
     G = nx.Graph()
     if distances is None:

--- a/src/tsam/utils/k_medoids_exact.py
+++ b/src/tsam/utils/k_medoids_exact.py
@@ -7,9 +7,20 @@ from sklearn.utils import check_array
 np.float_ = np.float64  # type: ignore[attr-defined]
 np.complex_ = np.complex128  # type: ignore[attr-defined]
 
-import pyomo.environ as pyomo
-import pyomo.opt as opt
-from pyomo.contrib import appsi
+
+def _import_pyomo():
+    """Lazy import pyomo with helpful error message."""
+    try:
+        import pyomo.environ as pyomo
+        import pyomo.opt as opt
+        from pyomo.contrib import appsi
+
+        return pyomo, opt, appsi
+    except ImportError:
+        raise ImportError(
+            "The k-medoids clustering method requires pyomo and a solver. "
+            "Install them with: pip install tsam[kmedoids]"
+        ) from None
 
 
 class KMedoids(BaseEstimator, ClusterMixin, TransformerMixin):
@@ -154,6 +165,8 @@ def _setup_k_medoids(distances, n_clusters):
     with an additional constraint of cluster-sizes/populations.
     (W Hess, JB Weaver, HJ Siegfeldt, JN Whelan, and PA Zitlau. Nonpartisan political redistricting by computer. Operations Research, 13(6):998–1006, 1965.)
     """
+    pyomo, _, _ = _import_pyomo()
+
     # Create model
     M = pyomo.ConcreteModel()
 
@@ -215,6 +228,8 @@ def _solve_given_pyomo_model(M, solver="highs"):
     Returns:
         [type]: [description]
     """
+    pyomo, opt, appsi = _import_pyomo()
+
     # create optimization problem
     if solver == "highs":
         solver_instance = appsi.solvers.Highs()


### PR DESCRIPTION
## Summary

- Move pyomo, highspy, and networkx from core dependencies to optional extras
- Default install now only requires scikit-learn, pandas, numpy, and tqdm
- Lazy imports with clear error messages guide users to install the right extra

### New extras

```
pip install tsam[kmedoids]    # pyomo + highspy
pip install tsam[contiguity]  # pyomo + highspy + networkx
pip install tsam[full]        # everything
```

## Test plan

- [x] All 823 tests pass with deps installed
- [ ] Verify `import tsam` works without pyomo/networkx installed
- [ ] Verify clear error message when using kmedoids without extra

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Moved `pyomo`, `highspy`, and `networkx` to optional dependencies for reduced installation size.
  * Introduced optional dependency groups: `kmedoids`, `contiguity`, and `full` for targeted feature installation.
  * Improved error messaging when optional dependencies are missing during feature use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->