### PR TITLE
Remove unstackToPeriods camelCase alias

### DIFF
--- a/src/tsam/__init__.py
+++ b/src/tsam/__init__.py
@@ -66,7 +66,7 @@ from tsam.options import options
 from tsam.result import AccuracyMetrics, AggregationResult
 
 # Legacy imports for backward compatibility
-from tsam.timeseriesaggregation import TimeSeriesAggregation, unstackToPeriods
+from tsam.timeseriesaggregation import TimeSeriesAggregation
 
 __version__ = "3.0.0"
 
@@ -85,6 +85,5 @@ __all__ = [
     "options",
     "plot",
     "tuning",
-    "unstackToPeriods",  # Legacy alias
     "unstack_to_periods",
 ]

--- a/src/tsam/timeseriesaggregation.py
+++ b/src/tsam/timeseriesaggregation.py
@@ -76,10 +76,6 @@ def unstack_to_periods(time_series, time_steps_per_period):
     return unstacked_time_series, time_index
 
 
-# Legacy alias
-unstackToPeriods = unstack_to_periods
-
-
 _PARAM_ALIASES = {
     "timeSeries": "time_series",
     "noTypicalPeriods": "no_typical_periods",


### PR DESCRIPTION
## Summary

- Remove `unstackToPeriods` alias from `__init__.py` exports and `timeseriesaggregation.py`
- The snake_case `unstack_to_periods` remains available
- v4 is a major version bump — the right time to drop legacy aliases

The `TimeSeriesAggregation` class retains its internal camelCase parameter/method aliases since the whole class is the legacy backward-compat layer.

## Test plan

- [x] No tests reference `unstackToPeriods`
- [x] Only docs mention it (can be updated separately)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed legacy alias from the public API. Users relying on the deprecated naming convention should migrate to the current function name to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->