### PR TITLE
Add py.typed marker for type checking support

### DIFF
--- a/src/tsam/py.typed
+++ b/src/tsam/py.typed
@@ -1,0 +1,1 @@
+# PEP 561 marker — this package supports type checking


### PR DESCRIPTION
## Summary

- Add `src/tsam/py.typed` PEP 561 marker file
- Signals to mypy/pyright that tsam ships inline type annotations
- Enables IDE autocompletion and type checking for downstream users

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)